### PR TITLE
Internals of board hidden from prompt

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -39,12 +39,24 @@ class Board
     if check_for_winning_row_of(:X, all_winning_combinations) 
       return :X 
     end
-  
+
     if check_for_winning_row_of(:O, all_winning_combinations) 
       return :O
     end
-   
+
     :unset
+  end
+
+  def grid_for_display
+    grid_formation = ""
+    (0...grid.size).each do |i|
+      if grid[i].nil?
+        grid_formation+="empty$"
+      else 
+        grid_formation+= grid[i].to_s + "$"
+      end 
+    end
+    grid_formation 
   end
 
   private

--- a/lib/prompt_writer.rb
+++ b/lib/prompt_writer.rb
@@ -19,8 +19,7 @@ class PromptWriter
 
   def show_board(board)
     board_to_display = ""
-    cells = board.grid
-
+    cells = board.grid_for_display.split("$")
     cells.each_index do |index|
       board_to_display = board_to_display + divider + display_cell(cells, index)
       board_to_display += add_new_line_if_end_of_row(index)
@@ -46,7 +45,7 @@ class PromptWriter
   end
 
   def display_cell(cells, index)
-    cells[index].nil? ? one_based(index).to_s : cells[index].to_s
+    cells[index] == "empty" ? one_based(index).to_s : cells[index].to_s
   end
 
   def divider

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Board do
     expect(board.grid.size).to eq(9)
   end
 
+  it "has grid formation" do
+    board = Board.new([nil, nil, nil, nil, :X, :O, nil, nil, nil])
+    expect(board.grid_for_display).to eq("empty$empty$empty$empty$X$O$empty$empty$empty$")
+  end
+
   it "updates board with a symbol at a given position" do
     board.update(1, :X)
     expect(board.grid).to eq([nil, :X, nil, nil, nil, nil, nil, nil, nil])


### PR DESCRIPTION
@jsuchy @ecomba

So that the prompt writer does not know the internal representation of the grid, a new method has been added to the board class, which exposes the grid in a string form. 

The prompt can then interpret this as it wishes for display. This provides a layer of abstraction between the internal representation of the board and clients of the Board class. This means, if the internal representation of the board changes, clients would not be effected.
