### PR TITLE
Remove duplication in board

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,5 +1,4 @@
 class Board
-  attr_accessor :grid 
 
   def initialize(symbols = Array.new(9))
     @grid = symbols
@@ -9,15 +8,19 @@ class Board
     !(grid.include?(:X) or grid.include?(:O))
   end
 
-  def update(index, symbol)
+  def make_move(index, symbol)
     grid_before_index = copy_portion_of_grid(index)
     grid_after_index = copy_portion_of_grid(grid.size - (index + 1))  
 
-    set_grid Array.new(grid_before_index + [symbol] + grid_after_index)
+    Board.new(Array.new(grid_before_index + [symbol] + grid_after_index))
   end
 
   def has_free_spaces 
     grid.include?(nil)
+  end
+
+  def get_symbol_at(position)
+    grid.at(position)
   end
 
   def has_winning_combination
@@ -61,9 +64,7 @@ class Board
 
   private
 
-  def set_grid(grid)
-    @grid = grid
-  end
+  attr_reader :grid
 
   def copy_portion_of_grid(size_of_portion_to_copy)
     temp_array = Array.new(size_of_portion_to_copy)

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -4,18 +4,17 @@ class Board
     @grid = symbols
   end
 
-  def is_empty
-    !(grid.include?(PlayerSymbols::X) or grid.include?(PlayerSymbols::O))
+  def empty?
+    grid.all?(&:nil?)
   end
 
   def make_move(index, symbol)
-    grid_before_index = copy_portion_of_grid(0, index)
-    grid_after_index = copy_portion_of_grid(index + 1, grid.size)   
-
-    Board.new(Array.new(grid_before_index + [symbol] + grid_after_index))
+    copy_of_grid = grid.dup
+    copy_of_grid[index] = symbol
+    Board.new(copy_of_grid)
   end
 
-  def has_free_spaces 
+  def free_spaces? 
     grid.include?(nil)
   end
 
@@ -23,8 +22,8 @@ class Board
     grid.at(position)
   end
 
-  def has_winning_combination
-    has_winning_combination_within(all_rows)
+  def winning_combination?
+    not_nil_row(find_winning_row_from(all_rows))
   end
 
   def winning_symbol
@@ -40,26 +39,10 @@ class Board
 
   attr_reader :grid
 
-  def copy_portion_of_grid(start_index, end_index)
-    grid[start_index...end_index] 
-  end
-
-  def has_winning_combination_within(all_rows) 
-    has_row_of_matching_symbols_within(all_rows) 
-  end
-
-  def has_row_of_matching_symbols_within(all_rows)
-    has_winning_row(all_rows) ? true : false
-  end
-
-  def has_winning_row(all_rows)
-    not_nil_row(find_winning_row_from(all_rows))
-  end
-
   def find_winning_row_from(rows)
-    all_rows.each do |row| 
+    rows.each do |row| 
       all_cells_match = row.all? {|cell| cell == row.first}
-      return row if all_cells_match and not_nil_symbol(row.first)
+      return row if all_cells_match && not_nil_symbol(row.first)
     end 
     return nil
   end
@@ -67,11 +50,9 @@ class Board
   def not_nil_row(row)
     !row.nil?
   end
+
   def all_rows
-    all_rows = []
-    all_rows += rows 
-    all_rows += columns 
-    all_rows += diagonals
+    rows + columns + diagonals
   end
 
   def not_nil_symbol(cell)
@@ -79,23 +60,26 @@ class Board
   end
 
   def rows
-    rows = [] 
-    rows << [grid.at(0), grid.at(1), grid.at(2)] 
-    rows << [grid.at(3), grid.at(4), grid.at(5)] 
-    rows << [grid.at(6), grid.at(7), grid.at(8)]
+    [ 
+      [grid.at(0), grid.at(1), grid.at(2)],
+      [grid.at(3), grid.at(4), grid.at(5)], 
+      [grid.at(6), grid.at(7), grid.at(8)]
+    ]
   end
 
   def columns
-    columns = []
-    columns << [grid.at(0), grid.at(3), grid.at(6)]
-    columns << [grid.at(1), grid.at(4), grid.at(7)]
-    columns << [grid.at(2), grid.at(5), grid.at(8)]
+    [
+      [grid.at(0), grid.at(3), grid.at(6)],
+      [grid.at(1), grid.at(4), grid.at(7)],
+      [grid.at(2), grid.at(5), grid.at(8)]
+    ] 
   end
 
   def diagonals
-    diagonals = []
-    diagonals << [grid.at(0),grid.at(4), grid.at(8)]
-    diagonals << [grid.at(2), grid.at(4), grid.at(6)]
+    [
+      [grid.at(0),grid.at(4), grid.at(8)],
+      [grid.at(2), grid.at(4), grid.at(6)]
+    ]
   end
 
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -9,8 +9,8 @@ class Board
   end
 
   def make_move(index, symbol)
-    grid_before_index = copy_portion_of_grid(index)
-    grid_after_index = copy_portion_of_grid(grid.size - (index + 1))  
+    grid_before_index = copy_portion_of_grid(0, index)
+    grid_after_index = copy_portion_of_grid(index + 1, grid.size)   
 
     Board.new(Array.new(grid_before_index + [symbol] + grid_after_index))
   end
@@ -66,12 +66,8 @@ class Board
 
   attr_reader :grid
 
-  def copy_portion_of_grid(size_of_portion_to_copy)
-    temp_array = Array.new(size_of_portion_to_copy)
-    (0...size_of_portion_to_copy).each do |i| 
-      temp_array[i] = grid[i] 
-    end
-    temp_array
+  def copy_portion_of_grid(start_index, end_index)
+    grid[start_index...end_index] 
   end
 
   def all_winning_combinations_for_3x3_grid

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -24,45 +24,16 @@ class Board
   end
 
   def has_winning_combination
-    all_rows = rows_for_3x3_grid
-
-    has_win_for_x = check_for_winning_row_of(:X, all_rows) 
-    has_win_for_o = check_for_winning_row_of(:O, all_rows)
-
-    has_win_for_x or has_win_for_o
-  end
-
-  def check_for_winning_row_of(symbol, all_rows) 
-    has_row_of_matching_symbols_within(all_rows) 
-  end
-
-  def has_row_of_matching_symbols_within(all_rows)
-    all_rows.each do |row| 
-      puts 'row is: ' + row.to_s
-      all_cells_match = row.all? {|cell| cell == row[0]}
-      if all_cells_match and not_nil_symbol(row[0])
-        return true
-      end
-    end 
-    return false
-  end
-
-  def not_nil_symbol(cell)
-    !cell.nil?
+    has_winning_combination_within(all_rows)
   end
 
   def winning_symbol
-    rows_for_3x3_grid.each do |row| 
-      all_cells_match = row.all? {|cell| cell == row[0]}
-      if all_cells_match and not_nil_symbol(row[0])
-        return row[0]
-      end
-    end 
-    return nil
+    winning_row = find_winning_row_from(all_rows)
+    winning_row.nil? ? nil : winning_row[0] 
   end
 
   def grid_for_display
-    indices_for_rows
+    rows
   end
 
   private
@@ -73,38 +44,57 @@ class Board
     grid[start_index...end_index] 
   end
 
-  def rows_for_3x3_grid
-    all_rows = []
-    all_rows += indices_for_rows 
-    all_rows += indices_for_columns 
-    all_rows += indices_for_diagonals
+  def has_winning_combination_within(all_rows) 
+    has_row_of_matching_symbols_within(all_rows) 
   end
 
-  def does_row_match_condition
-    rows_for_3x3_grid.each do |row| 
-      all_cells_match = row.all? {|cell| cell == row[0]}
-      if all_cells_match and not_nil_symbol(row[0])
-        return row[0]
+  def has_row_of_matching_symbols_within(all_rows)
+    has_winning_row(all_rows) ? true : false
+  end
+
+  def has_winning_row(all_rows)
+    not_nil_row(find_winning_row_from(all_rows))
+  end
+
+  def find_winning_row_from(rows)
+    all_rows.each do |row| 
+      all_cells_match = row.all? {|cell| cell == row.first}
+      if all_cells_match and not_nil_symbol(row.first)
+        return row
       end
     end 
     return nil
   end
 
-  def indices_for_rows
+  def not_nil_row(row)
+    !row.nil?
+  end
+  def all_rows
+    all_rows = []
+    all_rows += rows 
+    all_rows += columns 
+    all_rows += diagonals
+  end
+
+  def not_nil_symbol(cell)
+    !cell.nil?
+  end
+
+  def rows
     rows = [] 
     rows << [grid.at(0), grid.at(1), grid.at(2)] 
     rows << [grid.at(3), grid.at(4), grid.at(5)] 
     rows << [grid.at(6), grid.at(7), grid.at(8)]
   end
 
-  def indices_for_columns
+  def columns
     columns = []
     columns << [grid.at(0), grid.at(3), grid.at(6)]
     columns << [grid.at(1), grid.at(4), grid.at(7)]
     columns << [grid.at(2), grid.at(5), grid.at(8)]
   end
 
-  def indices_for_diagonals
+  def diagonals
     diagonals = []
     diagonals << [grid.at(0),grid.at(4), grid.at(8)]
     diagonals << [grid.at(2), grid.at(4), grid.at(6)]

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -24,94 +24,90 @@ class Board
   end
 
   def has_winning_combination
-    all_row_indices = row_indices_for_3x3_grid
+    all_rows = rows_for_3x3_grid
 
-    has_win_for_x = check_for_winning_row_of(:X, all_row_indices) 
-    has_win_for_o = check_for_winning_row_of(:O, all_row_indices)
+    has_win_for_x = check_for_winning_row_of(:X, all_rows) 
+    has_win_for_o = check_for_winning_row_of(:O, all_rows)
 
     has_win_for_x or has_win_for_o
   end
 
-  def check_for_winning_row_of(symbol, all_winning_combinations) 
-    all_indices_of_symbol = grid.each_index.select { |v| grid[v] == symbol} 
-    check_for_winning_combination_in(all_indices_of_symbol, all_winning_combinations)
+  def check_for_winning_row_of(symbol, all_rows) 
+    has_row_of_matching_symbols_within(all_rows) 
+  end
+
+  def has_row_of_matching_symbols_within(all_rows)
+    all_rows.each do |row| 
+      puts 'row is: ' + row.to_s
+      all_cells_match = row.all? {|cell| cell == row[0]}
+      if all_cells_match and not_nil_symbol(row[0])
+        return true
+      end
+    end 
+    return false
+  end
+
+  def not_nil_symbol(cell)
+    !cell.nil?
   end
 
   def winning_symbol
-    all_winning_combinations = row_indices_for_3x3_grid
-    if check_for_winning_row_of(:X, all_winning_combinations) 
-      return :X 
-    end
-
-    if check_for_winning_row_of(:O, all_winning_combinations) 
-      return :O
-    end
-    :unset
+    rows_for_3x3_grid.each do |row| 
+      all_cells_match = row.all? {|cell| cell == row[0]}
+      if all_cells_match and not_nil_symbol(row[0])
+        return row[0]
+      end
+    end 
+    return nil
   end
 
   def grid_for_display
-    all_rows = Array.new(3) 
-    offset = 0
-    indices_for_rows.each do |row_indices|
-      all_rows[offset] = create_row_for(row_indices)
-      offset += 1
-    end
-    all_rows
+    indices_for_rows
   end
 
   private
 
   attr_reader :grid
 
-  def create_row_for(row_indices) 
-    single_row = Array.new(3)
-    (0...3).each do |index| 
-      row_indices.each do |row_index|
-        single_row[index] = grid[row_indices[index]]
-      end
-    end
-    single_row 
-  end
-
   def copy_portion_of_grid(start_index, end_index)
     grid[start_index...end_index] 
   end
 
-  def row_indices_for_3x3_grid
-    all_winning_combinations = []
-    all_winning_combinations += indices_for_rows 
-    all_winning_combinations += indices_for_columns 
-    all_winning_combinations += indices_for_diagonals
+  def rows_for_3x3_grid
+    all_rows = []
+    all_rows += indices_for_rows 
+    all_rows += indices_for_columns 
+    all_rows += indices_for_diagonals
+  end
+
+  def does_row_match_condition
+    rows_for_3x3_grid.each do |row| 
+      all_cells_match = row.all? {|cell| cell == row[0]}
+      if all_cells_match and not_nil_symbol(row[0])
+        return row[0]
+      end
+    end 
+    return nil
   end
 
   def indices_for_rows
     rows = [] 
-    rows << [0, 1, 2] 
-    rows << [3, 4, 5] 
-    rows << [6, 7, 8]
+    rows << [grid.at(0), grid.at(1), grid.at(2)] 
+    rows << [grid.at(3), grid.at(4), grid.at(5)] 
+    rows << [grid.at(6), grid.at(7), grid.at(8)]
   end
 
   def indices_for_columns
     columns = []
-    columns << [0, 3, 6]
-    columns << [1, 4, 7]
-    columns << [2, 5, 8]
+    columns << [grid.at(0), grid.at(3), grid.at(6)]
+    columns << [grid.at(1), grid.at(4), grid.at(7)]
+    columns << [grid.at(2), grid.at(5), grid.at(8)]
   end
 
   def indices_for_diagonals
     diagonals = []
-    diagonals << [0, 4, 8]
-    diagonals << [2, 4, 6]
+    diagonals << [grid.at(0),grid.at(4), grid.at(8)]
+    diagonals << [grid.at(2), grid.at(4), grid.at(6)]
   end
 
-  def check_for_winning_combination_in(positions, all_winning_combinations)
-    all_winning_combinations.each do |r|
-      has_winning_combo =  r.all? { |element| positions.include?(element) }
-
-      if has_winning_combo
-        return true
-      end
-    end
-    return false
-  end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -59,9 +59,7 @@ class Board
   def find_winning_row_from(rows)
     all_rows.each do |row| 
       all_cells_match = row.all? {|cell| cell == row.first}
-      if all_cells_match and not_nil_symbol(row.first)
-        return row
-      end
+      return row if all_cells_match and not_nil_symbol(row.first)
     end 
     return nil
   end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -24,10 +24,10 @@ class Board
   end
 
   def has_winning_combination
-    all_winning_combinations = all_winning_combinations_for_3x3_grid
+    all_row_indices = row_indices_for_3x3_grid
 
-    has_win_for_x = check_for_winning_row_of(:X, all_winning_combinations) 
-    has_win_for_o = check_for_winning_row_of(:O, all_winning_combinations)
+    has_win_for_x = check_for_winning_row_of(:X, all_row_indices) 
+    has_win_for_o = check_for_winning_row_of(:O, all_row_indices)
 
     has_win_for_x or has_win_for_o
   end
@@ -38,7 +38,7 @@ class Board
   end
 
   def winning_symbol
-    all_winning_combinations = all_winning_combinations_for_3x3_grid
+    all_winning_combinations = row_indices_for_3x3_grid
     if check_for_winning_row_of(:X, all_winning_combinations) 
       return :X 
     end
@@ -46,52 +46,59 @@ class Board
     if check_for_winning_row_of(:O, all_winning_combinations) 
       return :O
     end
-
     :unset
   end
 
   def grid_for_display
-    grid_formation = ""
-    (0...grid.size).each do |i|
-      if grid[i].nil?
-        grid_formation+="empty$"
-      else 
-        grid_formation+= grid[i].to_s + "$"
-      end 
+    all_rows = Array.new(3) 
+    offset = 0
+    indices_for_rows.each do |row_indices|
+      all_rows[offset] = create_row_for(row_indices)
+      offset += 1
     end
-    grid_formation 
+    all_rows
   end
 
   private
 
   attr_reader :grid
 
+  def create_row_for(row_indices) 
+    single_row = Array.new(3)
+    (0...3).each do |index| 
+      row_indices.each do |row_index|
+        single_row[index] = grid[row_indices[index]]
+      end
+    end
+    single_row 
+  end
+
   def copy_portion_of_grid(start_index, end_index)
     grid[start_index...end_index] 
   end
 
-  def all_winning_combinations_for_3x3_grid
+  def row_indices_for_3x3_grid
     all_winning_combinations = []
-    all_winning_combinations += indices_for_winning_rows 
-    all_winning_combinations += indices_for_winning_columns 
-    all_winning_combinations += indices_for_winning_diagonals
+    all_winning_combinations += indices_for_rows 
+    all_winning_combinations += indices_for_columns 
+    all_winning_combinations += indices_for_diagonals
   end
 
-  def indices_for_winning_rows
+  def indices_for_rows
     rows = [] 
     rows << [0, 1, 2] 
     rows << [3, 4, 5] 
     rows << [6, 7, 8]
   end
 
-  def indices_for_winning_columns
+  def indices_for_columns
     columns = []
     columns << [0, 3, 6]
     columns << [1, 4, 7]
     columns << [2, 5, 8]
   end
 
-  def indices_for_winning_diagonals
+  def indices_for_diagonals
     diagonals = []
     diagonals << [0, 4, 8]
     diagonals << [2, 4, 6]

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -5,7 +5,7 @@ class Board
   end
 
   def is_empty
-    !(grid.include?(:X) or grid.include?(:O))
+    !(grid.include?(PlayerSymbols::X) or grid.include?(PlayerSymbols::O))
   end
 
   def make_move(index, symbol)
@@ -29,7 +29,7 @@ class Board
 
   def winning_symbol
     winning_row = find_winning_row_from(all_rows)
-    winning_row.nil? ? nil : winning_row[0] 
+    winning_row.nil? ? nil : winning_row.first 
   end
 
   def grid_for_display

--- a/lib/player_symbols.rb
+++ b/lib/player_symbols.rb
@@ -1,0 +1,4 @@
+class PlayerSymbols
+  X = :X 
+  O = :O
+end

--- a/lib/prompt_reader.rb
+++ b/lib/prompt_reader.rb
@@ -1,5 +1,4 @@
 class PromptReader
-  attr_reader :std_in
 
   def initialize(std_in)
     @std_in = std_in
@@ -8,4 +7,8 @@ class PromptReader
   def get_input()
     std_in.gets.chomp
   end
+ 
+  private 
+  
+  attr_reader :std_in
 end

--- a/lib/prompt_reader.rb
+++ b/lib/prompt_reader.rb
@@ -11,4 +11,5 @@ class PromptReader
   private 
   
   attr_reader :std_in
+
 end

--- a/lib/prompt_writer.rb
+++ b/lib/prompt_writer.rb
@@ -2,6 +2,7 @@ class PromptWriter
   def initialize(std_out)
     @std_out = std_out
   end
+  
   def ask_for_next_move
     std_out.puts "Please enter your next move"
   end

--- a/lib/prompt_writer.rb
+++ b/lib/prompt_writer.rb
@@ -1,7 +1,7 @@
 class PromptWriter
   def initialize(std_out)
     @std_out = std_out
-
+  end
   def ask_for_next_move
     std_out.puts "Please enter your next move"
   end
@@ -26,7 +26,7 @@ class PromptWriter
   private
 
   attr_reader :std_out 
-  
+
   def divider
     " | " 
   end
@@ -52,7 +52,7 @@ class PromptWriter
     cell.nil? ? one_based(cell_number).to_s : cell.to_s 
   end
 
-   def one_based(index)
+  def one_based(index)
     index + 1
   end
 

--- a/lib/prompt_writer.rb
+++ b/lib/prompt_writer.rb
@@ -1,7 +1,6 @@
 class PromptWriter
   def initialize(std_out)
     @std_out = std_out
-  end
 
   def ask_for_next_move
     std_out.puts "Please enter your next move"

--- a/lib/prompt_writer.rb
+++ b/lib/prompt_writer.rb
@@ -18,13 +18,7 @@ class PromptWriter
   end
 
   def show_board(board)
-    board_to_display = ""
-    cells = board.grid_for_display.split("$")
-
-    cells.each_index do |index|
-      board_to_display = board_to_display + divider + display_cell(cells, index)
-      board_to_display += add_new_line_if_end_of_row(index)
-    end
+    board_to_display = format_board(board)
     std_out.puts board_to_display
   end
 
@@ -38,19 +32,32 @@ class PromptWriter
     " | " 
   end
 
-  def display_cell(cells, index)
-    cells[index] == "empty" ? one_based(index).to_s : cells[index].to_s
+  def format_board(board)
+    board_to_display = ""  
+    cell_number = 0 
+    board.grid_for_display.each do |row|
+      row.each do |cell| 
+        board_to_display += format_row(cell, cell_number)
+        cell_number+=1
+      end
+      board_to_display += new_line
+    end
+    board_to_display   
   end
 
-  def one_based(index)
+  def format_row(cell_content, cell_number) 
+    divider + display_cell(cell_content, cell_number)
+  end
+
+  def display_cell(cell, cell_number)
+    cell.nil? ? one_based(cell_number).to_s : cell.to_s 
+  end
+
+   def one_based(index)
     index + 1
   end
 
-  def add_new_line_if_end_of_row(index)
-    if one_based(index) % 3 == 0
-      return " |\n"
-    end
-    return ""
+  def new_line
+    return " |\n"
   end
-
 end

--- a/lib/prompt_writer.rb
+++ b/lib/prompt_writer.rb
@@ -1,6 +1,4 @@
 class PromptWriter
-  attr_reader :std_out 
-
   def initialize(std_out)
     @std_out = std_out
   end
@@ -28,6 +26,8 @@ class PromptWriter
 
   private
 
+  attr_reader :std_out 
+  
   def divider
     " | " 
   end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Board do
   end
 
   it "is not empty when all slots are occupied" do
-    full_board = Board.new([:X, :O, :X, :O, :X, :O, :X, :X, :O]) 
+    full_board = Board.new([:X, :O, :X, :O, :X, :O, :X, :X, :O])
     expect(full_board.is_empty).to be false
   end
 
@@ -32,7 +32,7 @@ RSpec.describe Board do
   end
 
   it "has no free spaces when all slots are occupied" do
-    full_board = Board.new([:X, :O, :X, :O, :X, :O, :X, :X, :O]) 
+    full_board = Board.new([:X, :O, :X, :O, :X, :O, :X, :X, :O])
     expect(full_board.has_free_spaces).to be false
   end
 
@@ -107,6 +107,6 @@ RSpec.describe Board do
   end
 
   it "has no winning symbol" do
-    expect(board.winning_symbol).to be :unset
+    expect(board.winning_symbol).to be nil 
   end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Board do
   let (:board) {Board.new}
   
   it "is empty on initialisation" do
-    expect(board.is_empty).to be true
+    expect(board.empty?).to be true
   end
 
   it "is not empty when all slots are occupied" do
     full_board = Board.new([X, O, X, O, X, O, X, X, O])
-    expect(full_board.is_empty).to be false
+    expect(full_board.empty?).to be false
   end
 
   it "returns the current grid formation" do
@@ -32,72 +32,72 @@ RSpec.describe Board do
   end
 
   it "has free spaces" do
-    expect(board.has_free_spaces).to be true
+    expect(board.free_spaces?).to be true
   end
 
   it "has no free spaces when all slots are occupied" do
     full_board = Board.new([X, O, X, O, X, O, X, X, O])
-    expect(full_board.has_free_spaces).to be false
+    expect(full_board.free_spaces?).to be false
   end
 
   it "has no winning combination" do
     winning_board = Board.new([O, X, X, nil, nil, nil, nil, nil, nil])
-    expect(winning_board.has_winning_combination).to be false
+    expect(winning_board.winning_combination?).to be false
   end
 
   it "has winning combination of X in top row" do
     winning_board = Board.new([X, X, X, nil, nil, nil, nil, nil, nil])
-    expect(winning_board.has_winning_combination).to be true
+    expect(winning_board.winning_combination?).to be true
   end
 
   it "has winning combination of X in middle row" do
     winning_board = Board.new([nil, nil, nil, X, X, X, nil, nil, nil])
-    expect(winning_board.has_winning_combination).to be true
+    expect(winning_board.winning_combination?).to be true
   end
 
   it "has winning combination of X in bottom row" do
     winning_board = Board.new([nil, nil, nil, nil, nil, nil, X, X, X])
-    expect(winning_board.has_winning_combination).to be true
+    expect(winning_board.winning_combination?).to be true
   end
 
   it "has winning combination of X in left column" do
     winning_board = Board.new([X, nil, nil, X, nil, nil, X, nil, nil])
-    expect(winning_board.has_winning_combination).to be true
+    expect(winning_board.winning_combination?).to be true
   end
 
   it "has winning combination of X in middle column" do
     winning_board = Board.new([nil, X, nil, nil, X, nil, nil, X, nil])
-    expect(winning_board.has_winning_combination).to be true
+    expect(winning_board.winning_combination?).to be true
   end
 
   it "has winning combination of X in right column" do
     winning_board = Board.new([nil, nil, X, nil, nil, X, nil, nil, X])
-    expect(winning_board.has_winning_combination).to be true
+    expect(winning_board.winning_combination?).to be true
   end
 
   it "has winning combination of X in first diagonal" do
     winning_board = Board.new([X, nil, nil, nil, X, nil, nil, nil, X])
-    expect(winning_board.has_winning_combination).to be true
+    expect(winning_board.winning_combination?).to be true
   end
 
   it "has winning combination of X in second diagonal" do
     winning_board = Board.new([nil, nil, X, nil, X, nil, X, nil, nil])
-    expect(winning_board.has_winning_combination).to be true
+    expect(winning_board.winning_combination?).to be true
   end
 
   it "has winning combination of O in top row" do
     winning_board = Board.new([O, O, O, nil, nil, nil, nil, nil, nil])
-    expect(winning_board.has_winning_combination).to be true
+    expect(winning_board.winning_combination?).to be true
   end
 
   it "has winning combination of O in left column" do
     winning_board = Board.new([O, nil, nil, O, nil, nil, O, nil, nil])
-    expect(winning_board.has_winning_combination).to be true
+    expect(winning_board.winning_combination?).to be true
   end
 
   it "has winning combination of O in first diagonal" do
     winning_board = Board.new([O, nil, nil, nil, O, nil, nil, nil, O])
-    expect(winning_board.has_winning_combination).to be true
+    expect(winning_board.winning_combination?).to be true
   end
 
   it "has winning symbol X" do

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -1,30 +1,34 @@
 require 'board'
+require 'player_symbols'
 
 RSpec.describe Board do
+  X = PlayerSymbols::X
+  O = PlayerSymbols::O
+  
   let (:board) {Board.new}
-
+  
   it "is empty on initialisation" do
     expect(board.is_empty).to be true
   end
 
   it "is not empty when all slots are occupied" do
-    full_board = Board.new([:X, :O, :X, :O, :X, :O, :X, :X, :O])
+    full_board = Board.new([X, O, X, O, X, O, X, X, O])
     expect(full_board.is_empty).to be false
   end
 
   it "returns the current grid formation" do
-    board = Board.new([nil, nil, nil, nil, :X, :O, nil, nil, nil])
-    expect(board.grid_for_display).to eq([[nil, nil, nil], [nil, :X, :O], [nil, nil, nil]])
+    board = Board.new([nil, nil, nil, nil, X, O, nil, nil, nil])
+    expect(board.grid_for_display).to eq([[nil, nil, nil], [nil, X, O], [nil, nil, nil]])
   end
 
   it "can get symbol at given position" do
-    board = Board.new([nil, nil, nil, nil, :X, :O, nil, nil, nil])
+    board = Board.new([nil, nil, nil, nil, X, O, nil, nil, nil])
     expect(board.get_symbol_at(4)).to be :X
   end
 
   it "can be updated at a given position" do
-    updated_board = board.make_move(1, :X)
-    expect(updated_board.get_symbol_at(1)).to eq(:X)
+    updated_board = board.make_move(1, X)
+    expect(updated_board.get_symbol_at(1)).to eq(X)
   end
 
   it "has free spaces" do
@@ -32,78 +36,78 @@ RSpec.describe Board do
   end
 
   it "has no free spaces when all slots are occupied" do
-    full_board = Board.new([:X, :O, :X, :O, :X, :O, :X, :X, :O])
+    full_board = Board.new([X, O, X, O, X, O, X, X, O])
     expect(full_board.has_free_spaces).to be false
   end
 
   it "has no winning combination" do
-    winning_board = Board.new([:O, :X, :X, nil, nil, nil, nil, nil, nil])
+    winning_board = Board.new([O, X, X, nil, nil, nil, nil, nil, nil])
     expect(winning_board.has_winning_combination).to be false
   end
 
   it "has winning combination of X in top row" do
-    winning_board = Board.new([:X, :X, :X, nil, nil, nil, nil, nil, nil])
+    winning_board = Board.new([X, X, X, nil, nil, nil, nil, nil, nil])
     expect(winning_board.has_winning_combination).to be true
   end
 
   it "has winning combination of X in middle row" do
-    winning_board = Board.new([nil, nil, nil, :X, :X, :X, nil, nil, nil])
+    winning_board = Board.new([nil, nil, nil, X, X, X, nil, nil, nil])
     expect(winning_board.has_winning_combination).to be true
   end
 
   it "has winning combination of X in bottom row" do
-    winning_board = Board.new([nil, nil, nil, nil, nil, nil, :X, :X, :X])
+    winning_board = Board.new([nil, nil, nil, nil, nil, nil, X, X, X])
     expect(winning_board.has_winning_combination).to be true
   end
 
   it "has winning combination of X in left column" do
-    winning_board = Board.new([:X, nil, nil, :X, nil, nil, :X, nil, nil])
+    winning_board = Board.new([X, nil, nil, X, nil, nil, X, nil, nil])
     expect(winning_board.has_winning_combination).to be true
   end
 
   it "has winning combination of X in middle column" do
-    winning_board = Board.new([nil, :X, nil, nil, :X, nil, nil, :X, nil])
+    winning_board = Board.new([nil, X, nil, nil, X, nil, nil, X, nil])
     expect(winning_board.has_winning_combination).to be true
   end
 
   it "has winning combination of X in right column" do
-    winning_board = Board.new([nil, nil, :X, nil, nil, :X, nil, nil, :X])
+    winning_board = Board.new([nil, nil, X, nil, nil, X, nil, nil, X])
     expect(winning_board.has_winning_combination).to be true
   end
 
   it "has winning combination of X in first diagonal" do
-    winning_board = Board.new([:X, nil, nil, nil, :X, nil, nil, nil, :X])
+    winning_board = Board.new([X, nil, nil, nil, X, nil, nil, nil, X])
     expect(winning_board.has_winning_combination).to be true
   end
 
   it "has winning combination of X in second diagonal" do
-    winning_board = Board.new([nil, nil, :X, nil, :X, nil, :X, nil, nil])
+    winning_board = Board.new([nil, nil, X, nil, X, nil, X, nil, nil])
     expect(winning_board.has_winning_combination).to be true
   end
 
   it "has winning combination of O in top row" do
-    winning_board = Board.new([:O, :O, :O, nil, nil, nil, nil, nil, nil])
+    winning_board = Board.new([O, O, O, nil, nil, nil, nil, nil, nil])
     expect(winning_board.has_winning_combination).to be true
   end
 
   it "has winning combination of O in left column" do
-    winning_board = Board.new([:O, nil, nil, :O, nil, nil, :O, nil, nil])
+    winning_board = Board.new([O, nil, nil, O, nil, nil, O, nil, nil])
     expect(winning_board.has_winning_combination).to be true
   end
 
   it "has winning combination of O in first diagonal" do
-    winning_board = Board.new([:O, nil, nil, nil, :O, nil, nil, nil, :O])
+    winning_board = Board.new([O, nil, nil, nil, O, nil, nil, nil, O])
     expect(winning_board.has_winning_combination).to be true
   end
 
   it "has winning symbol X" do
-    winning_board = Board.new([:X, :X, :X, nil, nil, nil, nil, nil, nil])
-    expect(winning_board.winning_symbol).to be :X
+    winning_board = Board.new([X, X, X, nil, nil, nil, nil, nil, nil])
+    expect(winning_board.winning_symbol).to be X
   end
 
   it "has winning symbol O" do
-    winning_board = Board.new([:O, :O, :O, nil, nil, nil, nil, nil, nil])
-    expect(winning_board.winning_symbol).to be :O
+    winning_board = Board.new([O, O, O, nil, nil, nil, nil, nil, nil])
+    expect(winning_board.winning_symbol).to be O
   end
 
   it "has no winning symbol" do

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Board do
     expect(full_board.is_empty).to be false
   end
 
-  it "displays the current grid formation" do
+  it "returns the current grid formation" do
     board = Board.new([nil, nil, nil, nil, :X, :O, nil, nil, nil])
-    expect(board.grid_for_display).to eq("empty$empty$empty$empty$X$O$empty$empty$empty$")
+    expect(board.grid_for_display).to eq([[nil, nil, nil], [nil, :X, :O], [nil, nil, nil]])
   end
 
   it "can get symbol at given position" do

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -12,26 +12,19 @@ RSpec.describe Board do
     expect(full_board.is_empty).to be false
   end
 
-  it "has nine cells" do
-    expect(board.grid.size).to eq(9)
-  end
-
   it "displays the current grid formation" do
     board = Board.new([nil, nil, nil, nil, :X, :O, nil, nil, nil])
     expect(board.grid_for_display).to eq("empty$empty$empty$empty$X$O$empty$empty$empty$")
   end
 
-  it "can be upadated updated at a given position" do
-    board.update(1, :X)
-    expect(board.grid).to eq([nil, :X, nil, nil, nil, nil, nil, nil, nil])
+  it "can get symbol at given position" do
+    board = Board.new([nil, nil, nil, nil, :X, :O, nil, nil, nil])
+    expect(board.get_symbol_at(4)).to be :X
   end
 
-  it "returns a new copy of the board when an update is made" do
-    original_board = board.grid 
-    board.update(1, :X)
-    updated_board = board.grid
-
-    expect(updated_board.object_id).not_to eq(original_board.object_id)
+  it "can be updated at a given position" do
+    updated_board = board.make_move(1, :X)
+    expect(updated_board.get_symbol_at(1)).to eq(:X)
   end
 
   it "has free spaces" do
@@ -77,12 +70,12 @@ RSpec.describe Board do
     winning_board = Board.new([nil, nil, :X, nil, nil, :X, nil, nil, :X])
     expect(winning_board.has_winning_combination).to be true
   end
-  
+
   it "has winning combination of X in first diagonal" do
     winning_board = Board.new([:X, nil, nil, nil, :X, nil, nil, nil, :X])
     expect(winning_board.has_winning_combination).to be true
   end
-  
+
   it "has winning combination of X in second diagonal" do
     winning_board = Board.new([nil, nil, :X, nil, :X, nil, :X, nil, nil])
     expect(winning_board.has_winning_combination).to be true

--- a/spec/player_symbols_spec.rb
+++ b/spec/player_symbols_spec.rb
@@ -1,0 +1,12 @@
+require 'player_symbols'
+
+RSpec.describe PlayerSymbols do
+
+  it "has player symbol X" do
+    expect(PlayerSymbols::X).to be :X
+  end
+
+  it "has player symbol O" do
+    expect(PlayerSymbols::O).to be :O
+  end
+end

--- a/spec/prompt_reader_spec.rb
+++ b/spec/prompt_reader_spec.rb
@@ -1,6 +1,5 @@
 require 'prompt_reader'
 
-
 RSpec.describe PromptReader do
 
   it "reads input" do

--- a/spec/prompt_writer_spec.rb
+++ b/spec/prompt_writer_spec.rb
@@ -18,11 +18,6 @@ RSpec.describe PromptWriter do
     expect(@std_out.string).to eq "The game has been won by X!\n"
   end
 
-  it "displays winning message for O" do
-    @prompt.show_winning_message(:O) 
-    expect(@std_out.string).to eq "The game has been won by O!\n"
-  end
-
   it "displays draw message" do
     @prompt.show_draw_message
     expect(@std_out.string).to eq "The game is a draw!\n"

--- a/spec/prompt_writer_spec.rb
+++ b/spec/prompt_writer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PromptWriter do
   end
 
   it "displays winning message for X" do
-    @prompt.show_winning_message(X) 
+    @prompt.show_winning_message(PlayerSymbols::X) 
     expect(@std_out.string).to eq "The game has been won by X!\n"
   end
 
@@ -30,7 +30,7 @@ RSpec.describe PromptWriter do
   end
 
   it "displays board with occupied cells" do
-    board = Board.new([X, nil, nil, O, X, nil, nil, nil, nil])
+    board = Board.new([PlayerSymbols::X, nil, nil, PlayerSymbols::O, PlayerSymbols::X, nil, nil, nil, nil])
     @prompt.show_board(board)
     expect(@std_out.string).to eq(" | X | 2 | 3 |\n | O | X | 6 |\n | 7 | 8 | 9 |\n")
   end

--- a/spec/prompt_writer_spec.rb
+++ b/spec/prompt_writer_spec.rb
@@ -1,5 +1,6 @@
 require 'prompt_writer'
 require 'board'
+require 'player_symbols'
 
 RSpec.describe PromptWriter do
   before (:each) do
@@ -9,12 +10,11 @@ RSpec.describe PromptWriter do
 
   it "prompts for an input" do
     @prompt.ask_for_next_move
-
     expect(@std_out.string).to eq "Please enter your next move\n"
   end
 
   it "displays winning message for X" do
-    @prompt.show_winning_message(:X) 
+    @prompt.show_winning_message(X) 
     expect(@std_out.string).to eq "The game has been won by X!\n"
   end
 
@@ -30,7 +30,7 @@ RSpec.describe PromptWriter do
   end
 
   it "displays board with occupied cells" do
-    board = Board.new([:X, nil, nil, :O, :X, nil, nil, nil, nil])
+    board = Board.new([X, nil, nil, O, X, nil, nil, nil, nil])
     @prompt.show_board(board)
     expect(@std_out.string).to eq(" | X | 2 | 3 |\n | O | X | 6 |\n | 7 | 8 | 9 |\n")
   end


### PR DESCRIPTION
@jsuchy @ecomba
This board addresses the feedback from yesterdays IPM Meeting.

1) The board has been updated to be properly immutable. This has been achieved by returning a new instance of Board each time a move has been made by a player.
Additionally I realised I could simplify how I split up the array when copying it for the new board instance.

2) Duplication in checking for a winning row of O or X has been removed

3) Constants introduced for X and O

4) Instance variables made private
