### PR TITLE
Refactoring from ipm

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -9,13 +9,6 @@ require 'board_factory'
 require 'player_factory'
 require 'prompt_writer'
 require 'prompt_reader'
-require 'game'
-require 'board'
-require 'player_symbols'
-require 'human_player'
-require 'ai_player'
-require 'replay_option'
-require 'player_options'
 
 writer = PromptWriter.new($stdout)
 reader = PromptReader.new($stdin)

--- a/lib/ai_player.rb
+++ b/lib/ai_player.rb
@@ -1,3 +1,5 @@
+require 'player_symbols'
+
 class AiPlayer
 
   def initialize(symbol)
@@ -13,13 +15,13 @@ class AiPlayer
   end
 
   def minimax(board, is_max_player, depth)
-    best_score_so_far = initial_score(is_max_player)  
+    best_score_so_far = initial_score(is_max_player)
 
     if round_is_over(board, depth)
       return score(board, depth)
     end
 
-    board.vacant_indices.each do |i|  
+    board.vacant_indices.each do |i|
 
       new_board = board.make_move(i, current_players_symbol(is_max_player))
       result = minimax(new_board, !is_max_player, depth - 1)
@@ -34,16 +36,16 @@ class AiPlayer
   attr_reader :symbol
 
   def round_is_over(board, depth)
-    board.winning_combination? || depth == 0 
+    board.winning_combination? || depth == 0
   end
 
-  def score(board, depth) 
+  def score(board, depth)
     winning_symbol = board.winning_symbol
     if maximizing_player_won?(winning_symbol)
-      return MaximisingPlayerWin.new(depth) 
+      return MaximisingPlayerWin.new(depth)
     end
 
-    if minimizing_player_won?(winning_symbol) 
+    if minimizing_player_won?(winning_symbol)
       return MinimisingPlayerWin.new(depth)
     end
 
@@ -71,7 +73,7 @@ class AiPlayer
   end
 
   def current_players_symbol(is_max_player)
-    is_max_player == true ? game_symbol : PlayerSymbols::opponent(game_symbol) 
+    is_max_player == true ? game_symbol : PlayerSymbols::opponent(game_symbol)
   end
 
   def update_score(is_max_player, move, best_score_so_far, result_score)

--- a/lib/ai_player.rb
+++ b/lib/ai_player.rb
@@ -1,13 +1,11 @@
 require 'player_symbols'
+require 'player'
 
 class AiPlayer
+  include Player
 
   def initialize(symbol)
-    @symbol = symbol
-  end
-
-  def game_symbol
-    symbol
+    super(symbol)
   end
 
   def choose_move(board)
@@ -32,8 +30,6 @@ class AiPlayer
   end
 
   private
-
-  attr_reader :symbol
 
   def round_is_over(board, depth)
     board.winning_combination? || depth == 0

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -14,7 +14,7 @@ class Board
     Board.new(copy_of_grid)
   end
 
-  def free_spaces? 
+  def free_spaces?
     grid.include?(nil)
   end
 
@@ -28,7 +28,7 @@ class Board
 
   def winning_symbol
     winning_row = find_winning_row_from(all_rows)
-    winning_row.nil? ? nil : winning_row.first 
+    winning_row.nil? ? nil : winning_row.first
   end
 
   def vacant_indices
@@ -63,9 +63,9 @@ class Board
   end
 
   def rows
-    [ 
+    [
       [grid.at(0), grid.at(1), grid.at(2)],
-      [grid.at(3), grid.at(4), grid.at(5)], 
+      [grid.at(3), grid.at(4), grid.at(5)],
       [grid.at(6), grid.at(7), grid.at(8)]
     ]
   end
@@ -75,7 +75,7 @@ class Board
       [grid.at(0), grid.at(3), grid.at(6)],
       [grid.at(1), grid.at(4), grid.at(7)],
       [grid.at(2), grid.at(5), grid.at(8)]
-    ] 
+    ]
   end
 
   def diagonals

--- a/lib/board_factory.rb
+++ b/lib/board_factory.rb
@@ -1,3 +1,5 @@
+require 'board'
+
 class BoardFactory
 
   def create_board

--- a/lib/command_line_app.rb
+++ b/lib/command_line_app.rb
@@ -1,4 +1,4 @@
-require 'Game'
+require 'game'
 
 class CommandLineApp
 

--- a/lib/command_line_app.rb
+++ b/lib/command_line_app.rb
@@ -1,3 +1,5 @@
+require 'Game'
+
 class CommandLineApp
 
   def initialize(command_line_ui, board_factory, player_factory)
@@ -7,7 +9,7 @@ class CommandLineApp
   end
 
   def start
-    replay_option = true 
+    replay_option = true
     while user_wants_to_play?(replay_option)
       player_option = command_line_ui.get_player_option
       play_single_round(setup_game(player_option))
@@ -20,7 +22,7 @@ class CommandLineApp
     command_line_ui.print_game_status(final_board)
   end
 
-  private 
+  private
 
   attr_reader :game, :command_line_ui, :board_factory, :player_factory
 
@@ -29,6 +31,6 @@ class CommandLineApp
   end
 
   def setup_game(player_option)
-    Game.new(board_factory.create_board, player_factory.create_players(player_option, command_line_ui)) 
+    Game.new(board_factory.create_board, player_factory.create_players(player_option, command_line_ui))
   end
 end

--- a/lib/command_line_ui.rb
+++ b/lib/command_line_ui.rb
@@ -1,3 +1,7 @@
+require 'prompt_writer'
+require 'prompt_reader'
+require 'player_options'
+
 class CommandLineUI
 
   def initialize(writer, reader)
@@ -15,7 +19,7 @@ class CommandLineUI
   def replay?
     writer.replay
     replay_option = reader.get_input()
-    replay_option.upcase == ReplayOption::Y 
+    replay_option.upcase == ReplayOption::Y
   end
 
   def print_game_status(board)
@@ -40,11 +44,11 @@ class CommandLineUI
 
   def get_user_input_for_move
     writer.ask_for_next_move
-    value = reader.get_input  
+    value = reader.get_input
   end
 
   def get_user_input_for_player_options
-    writer.show_player_options 
+    writer.show_player_options
     value = reader.get_input
   end
 
@@ -56,17 +60,17 @@ class CommandLineUI
     PlayerOptions::get_player_type_for_id(value.to_i)
   end
 
-    def valid_player_option?(value) 
+    def valid_player_option?(value)
       PlayerOptions::valid_ids.include?(value.to_i)
     end
 
     def get_validated_move(value, board)
-      while !valid?(value, board) 
+      while !valid?(value, board)
         writer.show_board(board)
         writer.error_message
-        value = get_user_input_for_move   
+        value = get_user_input_for_move
       end
-      value.to_i    
+      value.to_i
     end
 
     def valid?(value, board)

--- a/lib/command_line_ui.rb
+++ b/lib/command_line_ui.rb
@@ -11,7 +11,7 @@ class CommandLineUI
 
   def get_move_from_player(board)
     writer.show_board(board)
-    value = get_user_input_for_move
+    value = read_users_move
 
     zero_indexed(get_validated_move(value, board))
   end
@@ -34,54 +34,64 @@ class CommandLineUI
   end
 
   def get_player_option
-    value = get_user_input_for_player_options
-    get_validated_player_option(value)
+    get_validated_player_option(read_player_option)
   end
 
   private
 
   attr_reader :writer, :reader
 
-  def get_user_input_for_move
+  def read_users_move
     writer.ask_for_next_move
-    value = reader.get_input
+    reader.get_input
   end
 
-  def get_user_input_for_player_options
+  def read_player_option
     writer.show_player_options
-    value = reader.get_input
+    reader.get_input
   end
 
   def get_validated_player_option(value)
     while !valid_player_option?(value)
       writer.error_message
-      value = get_user_input_for_player_options
+      value = read_player_option
     end
-    PlayerOptions::get_player_type_for_id(value.to_i)
+    PlayerOptions::get_player_type_for_id(to_number(value))
   end
 
-    def valid_player_option?(value)
-      PlayerOptions::valid_ids.include?(value.to_i)
-    end
-
-    def get_validated_move(value, board)
-      while !valid?(value, board)
-        writer.show_board(board)
-        writer.error_message
-        value = get_user_input_for_move
-      end
-      value.to_i
-    end
-
-    def valid?(value, board)
-      one_indexed(board.vacant_indices).include?(value.to_i)
-    end
-
-    def one_indexed(vacant_indices)
-      vacant_indices.collect { |i| i + 1 }
-    end
-
-    def zero_indexed(value)
-      value - 1
-    end
+  def valid_player_option?(value)
+    numeric?(value) ?  PlayerOptions::valid_ids.include?(to_number(value)) : false
   end
+
+  def get_validated_move(value, board)
+    while !valid?(value, board)
+      writer.show_board(board)
+      writer.error_message
+      value = read_users_move
+    end
+    to_number(value)
+  end
+
+  def valid?(value, board)
+    numeric?(value) ? one_indexed(board.vacant_indices).include?(to_number(value)) : false
+  end
+
+  def numeric?(input)
+    to_number(input)
+    true
+  rescue ArgumentError
+    false
+  end
+
+  def to_number(value)
+    Integer(value)
+  end
+
+  def one_indexed(vacant_indices)
+    vacant_indices.collect { |i| i + 1 }
+  end
+
+  def zero_indexed(value)
+    value - 1
+  end
+end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -5,13 +5,13 @@ class Game
     @players = players
   end
 
-  def play 
+  def play
     while game_in_progress
       current_player = players.first
-      @board = board.make_move(current_player.choose_move(board), current_player.game_symbol)  
+      @board = board.make_move(current_player.choose_move(board), current_player.game_symbol)
       players.reverse!
     end
-    board 
+    board
   end
 
   private

--- a/lib/human_player.rb
+++ b/lib/human_player.rb
@@ -1,18 +1,18 @@
+require 'player'
+
 class HumanPlayer
+  include Player
+
   def initialize(command_line_interface, symbol)
     @command_line_interface = command_line_interface
-    @symbol = symbol
+    super(symbol)
   end
 
   def choose_move(board)
     command_line_interface.get_move_from_player(board)
   end
 
-  def game_symbol
-    symbol
-  end
-
   private
 
-  attr_reader :command_line_interface, :symbol
+  attr_reader :command_line_interface
 end

--- a/lib/human_player.rb
+++ b/lib/human_player.rb
@@ -1,4 +1,4 @@
-class HumanPlayer 
+class HumanPlayer
   def initialize(command_line_interface, symbol)
     @command_line_interface = command_line_interface
     @symbol = symbol
@@ -12,7 +12,7 @@ class HumanPlayer
     symbol
   end
 
-  private 
+  private
 
   attr_reader :command_line_interface, :symbol
 end

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -1,0 +1,16 @@
+module Player
+
+  def initialize(symbol)
+    @symbol = symbol
+  end
+
+  def game_symbol
+    symbol
+  end
+
+  private
+
+  attr_reader :symbol
+
+end
+

--- a/lib/player_factory.rb
+++ b/lib/player_factory.rb
@@ -1,5 +1,9 @@
-class PlayerFactory
+require 'player_symbols'
+require 'human_player'
+require 'player_options'
+require 'ai_player'
 
+class PlayerFactory
   def create_players(player_option, command_line_ui)
     if player_option == PlayerOptions::HUMAN_VS_HUMAN
       human_vs_human(command_line_ui)

--- a/lib/player_options.rb
+++ b/lib/player_options.rb
@@ -10,7 +10,7 @@ class PlayerOptions
   }
 
   def self.valid_ids
-    ID_TO_PLAYER_TYPE.keys 
+    ID_TO_PLAYER_TYPE.keys
   end
 
   def self.get_player_type_for_id(id)

--- a/lib/player_options.rb
+++ b/lib/player_options.rb
@@ -3,9 +3,11 @@ class PlayerOptions
   HUMAN_VS_AI = "Human vs Ai"
   AI_VS_HUMAN = "Ai vs Human"
 
-  ID_TO_PLAYER_TYPE = { 1 => HUMAN_VS_HUMAN, 
-                        2 => HUMAN_VS_AI,
-                        3 => AI_VS_HUMAN }
+  ID_TO_PLAYER_TYPE = {
+    1 => HUMAN_VS_HUMAN,
+    2 => HUMAN_VS_AI,
+    3 => AI_VS_HUMAN
+  }
 
   def self.valid_ids
     ID_TO_PLAYER_TYPE.keys 
@@ -15,4 +17,28 @@ class PlayerOptions
     game_value_of_player = ID_TO_PLAYER_TYPE.fetch(id)
   end
 
+  def self.display_player_options
+    player_options_for_display = ID_TO_PLAYER_TYPE.each_pair.map do |id, option|
+      open_bracket + id.to_s + close_bracket + space + option
+    end
+    player_options_for_display.join(comma + space)
+  end
+
+  private
+
+  def self.open_bracket
+    "("
+  end
+
+  def self.close_bracket
+    ")"
+  end
+
+  def self.space
+    " "
+  end
+
+  def self.comma
+    ","
+  end
 end

--- a/lib/player_symbols.rb
+++ b/lib/player_symbols.rb
@@ -1,5 +1,5 @@
 class PlayerSymbols
-  X = :X 
+  X = :X
   O = :O
 
   def self.opponent(symbol)

--- a/lib/prompt_reader.rb
+++ b/lib/prompt_reader.rb
@@ -7,8 +7,8 @@ class PromptReader
   def get_input()
     std_in.gets.chomp
   end
- 
-  private 
-  
+
+  private
+
   attr_reader :std_in
 end

--- a/lib/prompt_writer.rb
+++ b/lib/prompt_writer.rb
@@ -1,3 +1,6 @@
+require 'replay_option'
+require 'player_options'
+
 class PromptWriter
   def initialize(std_out)
     @std_out = std_out
@@ -11,7 +14,7 @@ class PromptWriter
     std_out.puts "The game has been won by #{symbol}!"
   end
 
-  def show_draw_message 
+  def show_draw_message
     std_out.puts "The game is a draw!"
   end
 
@@ -34,14 +37,14 @@ class PromptWriter
 
   private
 
-  attr_reader :std_out 
+  attr_reader :std_out
 
   def divider
-    " | " 
+    " | "
   end
 
   def format_board(board)
-    cell_number = 0 
+    cell_number = 0
     divided_rows = board.grid_for_display.map do |row|
       formatted_cells = row.map do |cell|
         cell_number += 1
@@ -53,7 +56,7 @@ class PromptWriter
   end
 
   def display_cell(cell, cell_number)
-    cell.nil? ? cell_number.to_s : cell.to_s 
+    cell.nil? ? cell_number.to_s : cell.to_s
   end
 
   def new_line

--- a/lib/prompt_writer.rb
+++ b/lib/prompt_writer.rb
@@ -28,11 +28,11 @@ class PromptWriter
     std_out.puts "Incorrect input received!"
   end
 
- def show_player_options
-   std_out.puts "Choose player type: (1) #{PlayerOptions::HUMAN_VS_HUMAN}, (2) #{PlayerOptions::HUMAN_VS_AI}, (3) #{PlayerOptions::AI_VS_HUMAN}" 
- end
-  
- private
+  def show_player_options
+    std_out.puts "Choose player type: " + PlayerOptions.display_player_options
+  end
+
+  private
 
   attr_reader :std_out 
 

--- a/lib/replay_option.rb
+++ b/lib/replay_option.rb
@@ -1,3 +1,3 @@
 class ReplayOption
-  Y = "Y" 
+  Y = "Y"
 end

--- a/spec/ai_player_spec.rb
+++ b/spec/ai_player_spec.rb
@@ -28,112 +28,112 @@ RSpec.describe AiPlayer do
   it "takes a winning move on top row" do
     winning_move_on_top_row = Board.new([PlayerSymbols::X, nil, PlayerSymbols::X, nil, nil, PlayerSymbols::O, PlayerSymbols::O, nil, nil])
 
-    move = ai_player.choose_move(winning_move_on_top_row) 
+    move = ai_player.choose_move(winning_move_on_top_row)
     expect(move).to eq(1)
   end
 
   it "takes a winning move on middle row" do
     winning_move_on_middle_row = Board.new([PlayerSymbols::O, nil, nil, PlayerSymbols::X, nil, PlayerSymbols::X, PlayerSymbols::O, nil, PlayerSymbols::O])
 
-    move = ai_player.choose_move(winning_move_on_middle_row) 
+    move = ai_player.choose_move(winning_move_on_middle_row)
     expect(move).to eq(4)
   end
 
   it "takes a winning move on bottom row" do
     winning_move_on_bottom_row = Board.new([PlayerSymbols::O, nil, PlayerSymbols::O, PlayerSymbols::O, nil, PlayerSymbols::X, nil, PlayerSymbols::X, PlayerSymbols::X])
 
-    move = ai_player.choose_move(winning_move_on_bottom_row) 
+    move = ai_player.choose_move(winning_move_on_bottom_row)
     expect(move).to eq(6)
   end
 
   it "takes a winning move on left column" do
     winning_move_on_left_column = Board.new([PlayerSymbols::X, PlayerSymbols::O, nil, nil, nil, nil,  PlayerSymbols::X, nil, PlayerSymbols::O])
 
-    move = ai_player.choose_move(winning_move_on_left_column) 
+    move = ai_player.choose_move(winning_move_on_left_column)
     expect(move).to eq(3)
   end
 
   it "takes a winning move on middle column" do
     winning_move_on_middle_column = Board.new([nil, PlayerSymbols::X, PlayerSymbols::O, PlayerSymbols::O, PlayerSymbols::X, nil, nil, nil, nil])
 
-    move = ai_player.choose_move(winning_move_on_middle_column) 
+    move = ai_player.choose_move(winning_move_on_middle_column)
     expect(move).to eq(7)
   end
 
   it "takes a winning move on right column" do
     winning_move_on_right_column = Board.new([nil, PlayerSymbols::O, PlayerSymbols::X, nil, PlayerSymbols::O, nil, nil, nil, PlayerSymbols::X])
 
-    move = ai_player.choose_move(winning_move_on_right_column) 
+    move = ai_player.choose_move(winning_move_on_right_column)
     expect(move).to eq(5)
   end
 
   it "takes a winning move on first diagonal" do
     winning_move_on_first_diagonal = Board.new([PlayerSymbols::X, nil, PlayerSymbols::O, nil, nil, PlayerSymbols::O, nil, nil, PlayerSymbols::X])
 
-    move = ai_player.choose_move(winning_move_on_first_diagonal) 
+    move = ai_player.choose_move(winning_move_on_first_diagonal)
     expect(move).to eq(4)
   end
 
   it "takes a winning move on second diagonal" do
     winning_move_on_second_diagonal = Board.new([PlayerSymbols::O, nil, nil, nil, PlayerSymbols::X, nil, PlayerSymbols::X, PlayerSymbols::O, nil])
 
-    move = ai_player.choose_move(winning_move_on_second_diagonal) 
+    move = ai_player.choose_move(winning_move_on_second_diagonal)
     expect(move).to eq(2)
   end
 
   it "takes a blocking move on top row" do
     blocking_move_on_top_row = Board.new([PlayerSymbols::O, nil, PlayerSymbols::O, PlayerSymbols::X, nil, nil, nil, nil, PlayerSymbols::X])
 
-    move = ai_player.choose_move(blocking_move_on_top_row) 
+    move = ai_player.choose_move(blocking_move_on_top_row)
     expect(move).to eq(1)
   end
 
   it "takes a blocking move on middle row" do
     blocking_move_on_middle_row = Board.new([PlayerSymbols::X, PlayerSymbols::O, PlayerSymbols::X, PlayerSymbols::O, PlayerSymbols::O, nil, nil, PlayerSymbols::X, nil])
 
-    move = ai_player.choose_move(blocking_move_on_middle_row) 
+    move = ai_player.choose_move(blocking_move_on_middle_row)
     expect(move).to eq(5)
   end
 
   it "takes a blocking move on bottom row" do
     blocking_move_on_bottom_row = Board.new([PlayerSymbols::X, PlayerSymbols::O, PlayerSymbols::X, nil, nil, PlayerSymbols::X, nil, PlayerSymbols::O, PlayerSymbols::O])
 
-    move = ai_player.choose_move(blocking_move_on_bottom_row) 
+    move = ai_player.choose_move(blocking_move_on_bottom_row)
     expect(move).to eq(6)
   end
 
   it "takes a blocking move on left column" do
     blocking_move_on_left_column = Board.new([PlayerSymbols::O, nil, nil, nil, nil, PlayerSymbols::X, PlayerSymbols::O, PlayerSymbols::X, nil])
 
-    move = ai_player.choose_move(blocking_move_on_left_column) 
+    move = ai_player.choose_move(blocking_move_on_left_column)
     expect(move).to eq(3)
   end
 
   it "takes a blocking move on middle column" do
     blocking_move_on_middle_column = Board.new([nil, PlayerSymbols::O, nil, PlayerSymbols::X,nil, nil, nil, PlayerSymbols::O, nil])
 
-    move = ai_player.choose_move(blocking_move_on_middle_column) 
+    move = ai_player.choose_move(blocking_move_on_middle_column)
     expect(move).to eq(4)
   end
 
   it "takes a blocking move on right column" do
     blocking_move_on_right_column = Board.new([nil, nil, PlayerSymbols::O, nil, nil, PlayerSymbols::O, nil, PlayerSymbols::X, nil])
 
-    move = ai_player.choose_move(blocking_move_on_right_column) 
+    move = ai_player.choose_move(blocking_move_on_right_column)
     expect(move).to eq(8)
   end
 
  it "takes a blocking move on first diagonal" do
     blocking_move_on_first_diagonal = Board.new([PlayerSymbols::O, PlayerSymbols::X, nil, nil,nil, nil, nil, nil, PlayerSymbols::O])
 
-    move = ai_player.choose_move(blocking_move_on_first_diagonal) 
+    move = ai_player.choose_move(blocking_move_on_first_diagonal)
     expect(move).to eq(4)
   end
 
  it "takes a blocking move on second diagonal" do
     blocking_move_on_second_diagonal = Board.new([nil, nil, PlayerSymbols::O, nil, nil, nil, PlayerSymbols::O, PlayerSymbols::X, nil])
 
-    move = ai_player.choose_move(blocking_move_on_second_diagonal) 
+    move = ai_player.choose_move(blocking_move_on_second_diagonal)
     expect(move).to eq(4)
   end
 end

--- a/spec/ai_player_spec.rb
+++ b/spec/ai_player_spec.rb
@@ -1,5 +1,4 @@
 require 'ai_player'
-require 'player_symbols'
 require 'board'
 
 RSpec.describe AiPlayer do

--- a/spec/board_factory_spec.rb
+++ b/spec/board_factory_spec.rb
@@ -1,5 +1,4 @@
 require 'board_factory'
-require 'board'
 
 RSpec.describe BoardFactory do
   let(:board_factory) { BoardFactory.new }

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Board do
   end
 
   it "has no winning symbol" do
-    expect(board.winning_symbol).to be nil 
+    expect(board.winning_symbol).to be nil
   end
 
   it "gives all vacant indices on an empty board" do

--- a/spec/command_line_app_spec.rb
+++ b/spec/command_line_app_spec.rb
@@ -1,13 +1,10 @@
 require 'command_line_app'
-require 'game'
 require 'command_line_ui'
 require 'board'
-require 'human_player'
 require 'command_line_ui'
 require 'player_symbols'
 require 'player_factory'
 require 'board_factory'
-require 'player_options'
 
 RSpec.describe CommandLineApp do
   let(:command_line_app) { CommandLineApp.new(command_line_ui_spy, board_factory_spy, player_factory_spy) }
@@ -30,7 +27,7 @@ RSpec.describe CommandLineApp do
   end
 
   it "creates board on start" do
-    allow(board_factory_spy).to receive(:create_board).and_return(board_spy) 
+    allow(board_factory_spy).to receive(:create_board).and_return(board_spy)
     allow(command_line_ui_spy).to receive(:replay?).and_return(false)
 
     command_line_app.start
@@ -39,9 +36,9 @@ RSpec.describe CommandLineApp do
   end
 
   it "asks for player types" do
-    allow(board_factory_spy).to receive(:create_board).and_return(board_spy) 
+    allow(board_factory_spy).to receive(:create_board).and_return(board_spy)
     allow(command_line_ui_spy).to receive(:replay?).and_return(false)
-    
+
     command_line_app.start
 
     expect(board_factory_spy).to have_received(:create_board)
@@ -51,7 +48,7 @@ RSpec.describe CommandLineApp do
   it "creates players on start" do
     allow(player_factory_spy).to receive(:create_players).and_return(["player1", "player2"])
     allow(command_line_ui_spy).to receive(:replay?).and_return(false)
-    allow(board_factory_spy).to receive(:create_board).and_return(board_spy) 
+    allow(board_factory_spy).to receive(:create_board).and_return(board_spy)
 
     command_line_app.start
 
@@ -59,7 +56,7 @@ RSpec.describe CommandLineApp do
   end
 
   it "asks user to replay" do
-    allow(board_factory_spy).to receive(:create_board).and_return(board_spy) 
+    allow(board_factory_spy).to receive(:create_board).and_return(board_spy)
 
     command_line_app.start
 
@@ -67,7 +64,7 @@ RSpec.describe CommandLineApp do
   end
 
   it "play another game when replay selected" do
-    allow(board_factory_spy).to receive(:create_board).and_return(board_spy).twice 
+    allow(board_factory_spy).to receive(:create_board).and_return(board_spy).twice
     allow(command_line_ui_spy).to receive(:replay?).and_return(true, false)
 
     command_line_app.start

--- a/spec/command_line_ui_spec.rb
+++ b/spec/command_line_ui_spec.rb
@@ -1,11 +1,6 @@
 require 'command_line_ui'
 require 'board'
 require 'player_symbols'
-require 'player_symbols'
-require 'prompt_reader'
-require 'prompt_writer'
-require 'replay_option'
-require 'player_options'
 
 RSpec.describe CommandLineUI do
   let (:reader_spy) { instance_double(PromptReader).as_null_object }

--- a/spec/command_line_ui_spec.rb
+++ b/spec/command_line_ui_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CommandLineUI do
   it "displays error message when reprompted" do
     allow(reader_spy).to receive(:get_input).and_return("a", "3")
 
-    command_line_ui.get_move_from_player(Board.new)  
+    command_line_ui.get_move_from_player(Board.new)
 
     expect(writer_spy).to have_received(:error_message)
   end
@@ -40,7 +40,7 @@ RSpec.describe CommandLineUI do
   it "displays board with every reprompt" do
     allow(reader_spy).to receive(:get_input).and_return("a", "3")
 
-    command_line_ui.get_move_from_player(Board.new)  
+    command_line_ui.get_move_from_player(Board.new)
 
     expect(writer_spy).to have_received(:show_board).twice
   end
@@ -71,7 +71,7 @@ RSpec.describe CommandLineUI do
   it "reads replay option Y" do
     allow(reader_spy).to receive(:get_input).and_return("Y")
 
-    expect(command_line_ui.replay?).to be true 
+    expect(command_line_ui.replay?).to be true
 
     expect(writer_spy).to have_received(:replay)
   end
@@ -79,13 +79,13 @@ RSpec.describe CommandLineUI do
   it "reads replay option y" do
     allow(reader_spy).to receive(:get_input).and_return("y")
 
-    expect(command_line_ui.replay?).to be true 
+    expect(command_line_ui.replay?).to be true
   end
 
   it "replay is false when non valid option entered" do
     allow(reader_spy).to receive(:get_input).and_return("Z")
 
-    expect(command_line_ui.replay?).to be false 
+    expect(command_line_ui.replay?).to be false
 
     expect(writer_spy).to have_received(:replay)
   end
@@ -93,7 +93,7 @@ RSpec.describe CommandLineUI do
   it "prints winning game status" do
     winning_board = Board.new([PlayerSymbols::X, PlayerSymbols::X, PlayerSymbols::X, nil, nil, nil, nil, PlayerSymbols::O, PlayerSymbols::O])
 
-    command_line_ui.print_game_status(winning_board)  
+    command_line_ui.print_game_status(winning_board)
 
     expect(writer_spy).to have_received(:show_winning_message)
   end
@@ -101,7 +101,7 @@ RSpec.describe CommandLineUI do
   it "prints winning board" do
     winning_board = Board.new([PlayerSymbols::X, PlayerSymbols::X, PlayerSymbols::X, nil, nil, nil, nil, PlayerSymbols::O, PlayerSymbols::O])
 
-    command_line_ui.print_game_status(winning_board)  
+    command_line_ui.print_game_status(winning_board)
 
     expect(writer_spy).to have_received(:show_board)
   end
@@ -109,14 +109,14 @@ RSpec.describe CommandLineUI do
   it "prints draw game status" do
     drawn_board = Board.new([PlayerSymbols::X, PlayerSymbols::X, PlayerSymbols::O, PlayerSymbols::O, PlayerSymbols::X, PlayerSymbols::X, PlayerSymbols::X, PlayerSymbols::O, PlayerSymbols::O])
 
-    command_line_ui.print_game_status(drawn_board)  
+    command_line_ui.print_game_status(drawn_board)
 
     expect(writer_spy).to have_received(:show_draw_message)
   end
 
   it "displays player types" do
     allow(reader_spy).to receive(:get_input).and_return("1")
-    
+
     command_line_ui.get_player_option
 
     expect(writer_spy).to have_received(:show_player_options)
@@ -124,13 +124,13 @@ RSpec.describe CommandLineUI do
 
   it "reads in player option" do
     allow(reader_spy).to receive(:get_input).and_return("1")
-    
+
     expect(command_line_ui.get_player_option).to be PlayerOptions::HUMAN_VS_HUMAN
   end
 
   it "reprompts when invalid player option entered" do
     allow(reader_spy).to receive(:get_input).and_return("A", "1")
-   
+
     command_line_ui.get_player_option
 
     expect(writer_spy).to have_received(:error_message)

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -1,7 +1,7 @@
+require 'game'
 require 'board'
 require 'human_player'
 require 'player_symbols'
-require 'game'
 
 RSpec.describe Game do
   let(:player_x_spy) { instance_double(HumanPlayer).as_null_object }

--- a/spec/human_player_spec.rb
+++ b/spec/human_player_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe HumanPlayer do
 
     move = human.choose_move(Board.new)
 
-    expect(move).to be 1 
+    expect(move).to be 1
   end
 
-  it "has a player symbol" do 
+  it "has a player symbol" do
     expect(human.game_symbol).to be PlayerSymbols::X
   end
 end

--- a/spec/player_factory_spec.rb
+++ b/spec/player_factory_spec.rb
@@ -1,9 +1,5 @@
 require 'player_factory'
-require 'human_player'
-require 'ai_player'
 require 'command_line_ui'
-require 'player_symbols'
-require 'player_options'
 
 RSpec.describe PlayerFactory do
   let(:player_factory) { PlayerFactory.new }
@@ -22,7 +18,7 @@ RSpec.describe PlayerFactory do
     expect(players[0].class).to be HumanPlayer
     expect(players[1].class).to be AiPlayer
   end
-  
+
   it "creates a human and a ai computer player" do
     players = player_factory.create_players(PlayerOptions::AI_VS_HUMAN, command_line_ui_spy)
 

--- a/spec/player_options_spec.rb
+++ b/spec/player_options_spec.rb
@@ -21,4 +21,8 @@ RSpec.describe PlayerOptions do
   it "gets player type for id" do
     expect(PlayerOptions::get_player_type_for_id(1)).to eq (PlayerOptions::HUMAN_VS_HUMAN)
   end
+
+  it "gets player options for display" do
+ expect(PlayerOptions::display_player_options).to eq("(1) #{PlayerOptions::HUMAN_VS_HUMAN}, (2) #{PlayerOptions::HUMAN_VS_AI}, (3) #{PlayerOptions::AI_VS_HUMAN}" )
+  end
 end

--- a/spec/player_symbols_spec.rb
+++ b/spec/player_symbols_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PlayerSymbols do
   it "finds opponent of X" do
     expect(PlayerSymbols::opponent(PlayerSymbols::X)).to be :O
   end
-  
+
   it "finds opponent of O" do
     expect(PlayerSymbols::opponent(PlayerSymbols::O)).to be :X
   end

--- a/spec/prompt_reader_spec.rb
+++ b/spec/prompt_reader_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PromptReader do
     reader = PromptReader.new(std_in)
 
     value = reader.get_input()
-    
+
     expect(value).to eq "1"
   end
 end

--- a/spec/prompt_writer_spec.rb
+++ b/spec/prompt_writer_spec.rb
@@ -1,20 +1,18 @@
 require 'prompt_writer'
 require 'board'
 require 'player_symbols'
-require 'replay_option'
-require 'player_options'
 
 RSpec.describe PromptWriter do
   let(:std_out) { StringIO.new }
   let(:prompt) { PromptWriter.new(std_out) }
-  
+
   it "prompts for an input" do
     prompt.ask_for_next_move
     expect(std_out.string).to eq "Please enter your next move\n"
   end
 
   it "displays winning message for X" do
-    prompt.show_winning_message(PlayerSymbols::X) 
+    prompt.show_winning_message(PlayerSymbols::X)
     expect(std_out.string).to eq "The game has been won by X!\n"
   end
 

--- a/spec/replay_option_spec.rb
+++ b/spec/replay_option_spec.rb
@@ -3,6 +3,6 @@ require 'replay_option'
 RSpec.describe ReplayOption do
 
   it "has replay option of Y" do
-    expect(ReplayOption::Y.include?("Y")).to be true 
+    expect(ReplayOption::Y.include?("Y")).to be true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,10 +22,10 @@ require 'coveralls'
 
 Coveralls.wear!
 SimpleCov.minimum_coverage 100
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
       Coveralls::SimpleCov::Formatter
-]
+])
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
@jsuchy
- In prompt_writer.rb, rather than using to_i to parse the string to a number, Integer(n) is used.
- Mixin used to provide inheritance between the players
- Write prompt gets the id's from the PlayerOptions constant
- run.sh only requires the minimum number of classes now. Require statements moved into their relevant classes rathe rather than only being in the spec classes.
- SimpleCov now generates a report so you can see coverage when running locally.
- Trailing white spaces removed from files
