### PR TITLE
Simplify minimax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,10 @@
 source 'https://rubygems.org'
-gem 'rspec', :require => 'spec'
+gem 'pry'
+gem 'pry-byebug'
 
 group :test do
     gem 'rake'
     gem 'simplecov'
     gem 'coveralls', :require => false
+gem 'rspec', :require => 'spec'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ group :test do
     gem 'rake'
     gem 'simplecov'
     gem 'coveralls', :require => false
-gem 'rspec', :require => 'spec'
+    gem 'rspec', :require => 'spec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
+    coderay (1.1.0)
+    columnize (0.9.0)
     coveralls (0.8.10)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
@@ -8,6 +13,7 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (~> 1.6.0)
+    debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.25)
@@ -15,9 +21,17 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     json (1.8.3)
+    method_source (0.8.2)
     mime-types (2.99)
     netrc (0.11.0)
-    rake (10.4.2)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    pry-byebug (1.3.2)
+      byebug (~> 2.7)
+      pry (~> 0.9.12)
+    rake (10.5.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -40,6 +54,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
@@ -53,6 +68,8 @@ PLATFORMS
 
 DEPENDENCIES
   coveralls
+  pry
+  pry-byebug
   rake
   rspec
   simplecov

--- a/lib/ai_player.rb
+++ b/lib/ai_player.rb
@@ -9,7 +9,7 @@ class AiPlayer
   end
 
   def choose_move(board)
-    minimax(board, true, board.vacant_indices.size).get_move
+    minimax(board, true, board.vacant_indices.size).first[1]
   end
 
   def minimax(board, is_max_player, depth)
@@ -20,12 +20,10 @@ class AiPlayer
     end
 
     board.vacant_indices.each do |i|
-
       new_board = board.make_move(i, current_players_symbol(is_max_player))
       result = minimax(new_board, !is_max_player, depth - 1)
-      best_score_so_far = update_score(is_max_player, i, best_score_so_far, result.get_score)
+      best_score_so_far = update_score(is_max_player, i, best_score_so_far, result.first[0])
     end
-
     best_score_so_far
   end
 
@@ -38,14 +36,14 @@ class AiPlayer
   def score(board, depth)
     winning_symbol = board.winning_symbol
     if maximizing_player_won?(winning_symbol)
-      return MaximisingPlayerWin.new(depth)
+      return {(1 + depth) => nil}
     end
 
     if minimizing_player_won?(winning_symbol)
-      return MinimisingPlayerWin.new(depth)
+      return {(-1 - depth) => nil}
     end
 
-    return DrawScoredMove.new
+    return {0 => nil}
   end
 
   def maximizing_player_won?(winners_symbol)
@@ -62,9 +60,9 @@ class AiPlayer
 
   def initial_score(is_max_player)
     if is_max_player
-      best_score_so_far = MaximisingPlayerInitialScore.new
+      best_score_so_far = {-2 => nil}
     else
-      best_score_so_far = MinimisingPlayerInitialScore.new
+      best_score_so_far = {2 => nil}
     end
   end
 
@@ -73,63 +71,11 @@ class AiPlayer
   end
 
   def update_score(is_max_player, move, best_score_so_far, result_score)
-    if is_max_player && (result_score >= best_score_so_far.get_score)
-      return ScoredMove.new(move, result_score)
-    elsif !is_max_player && (result_score < best_score_so_far.get_score)
-      return ScoredMove.new(move, result_score)
+    if is_max_player && (result_score >= best_score_so_far.first[0])
+      return {result_score => move}
+    elsif !is_max_player && (result_score < best_score_so_far.first[0])
+      return {result_score => move}
     end
     return best_score_so_far
-  end
-end
-
-class ScoredMove
-
-  def initialize(move = nil, score)
-    @move = move
-    @score = score
-  end
-
-  def get_score
-    score
-  end
-
-  def get_move
-    move
-  end
-
-  private
-
-  attr_accessor :move
-  attr_accessor :score
-end
-
-class MaximisingPlayerInitialScore < ScoredMove
-
-  def initialize(move = nil, score = -2)
-    super(move, score)
-  end
-end
-
-class MinimisingPlayerInitialScore < ScoredMove
-  def initialize(move = nil, score = 2)
-    super(move, score)
-  end
-end
-
-class DrawScoredMove < ScoredMove
-  def initialize(move = nil, score = 0)
-    super(move, score)
-  end
-end
-
-class MaximisingPlayerWin < ScoredMove
-  def initialize(move = nil, score)
-    super(move, 1 + score)
-  end
-end
-
-class MinimisingPlayerWin < ScoredMove
-  def initialize(move = nil, score)
-    super(move, -1 - score)
   end
 end

--- a/lib/ai_player.rb
+++ b/lib/ai_player.rb
@@ -22,7 +22,7 @@ class AiPlayer
     board.vacant_indices.each do |i|
       new_board = board.make_move(i, current_players_symbol(is_max_player))
       result = minimax(new_board, !is_max_player, depth - 1, alpha, beta)
-      best_score_so_far = update_score(is_max_player, i, best_score_so_far, result.first[0])
+      best_score_so_far = update_score(is_max_player, i, best_score_so_far, score_from(result))
 
       alpha = update_alpha(is_max_player, best_score_so_far, alpha)
       beta = update_beta(is_max_player, best_score_so_far, beta)
@@ -37,19 +37,24 @@ class AiPlayer
 
 
   private
+
   ALPHA = -2
   BETA = 2
 
   def update_alpha(is_max_player, best_score_so_far, alpha)
-    if is_max_player && best_score_so_far.first.first > alpha
-      alpha = best_score_so_far.first.first
+    if is_max_player && score_from(best_score_so_far) > alpha
+      alpha = score_from(best_score_so_far)
     end
     alpha
   end
 
+  def score_from(score)
+    score.first.first
+  end
+
   def update_beta(is_max_player, best_score_so_far, beta)
-    if !is_max_player && best_score_so_far.first.first < beta
-      beta = best_score_so_far.first.first
+    if !is_max_player && score_from(best_score_so_far) < beta
+        beta = score_from(best_score_so_far)
     end
     beta
   end
@@ -97,12 +102,12 @@ class AiPlayer
     is_max_player == true ? game_symbol : PlayerSymbols::opponent(game_symbol)
   end
 
-  def update_score(is_max_player, move, best_score_so_far, result_score)
-    if is_max_player && (result_score >= best_score_so_far.first[0])
+  def update_score(is_max_player, move, score, result_score)
+    if is_max_player && (result_score >= score_from(score))
       return {result_score => move}
-    elsif !is_max_player && (result_score < best_score_so_far.first[0])
+    elsif !is_max_player && (result_score < score_from(score))
       return {result_score => move}
     end
-    return best_score_so_far
+    return score
   end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -27,8 +27,8 @@ class Board
   end
 
   def winning_symbol
-    winning_row = find_winning_row_from(all_rows)
-    winning_row.nil? ? nil : winning_row.first
+    @winning_row = find_winning_row_from(all_rows)
+    @winning_row.nil? ? nil : @winning_row.first
   end
 
   def vacant_indices
@@ -44,10 +44,10 @@ class Board
   attr_reader :grid
 
   def find_winning_row_from(rows)
-    rows.find do |row|
-       all_cells_match = row.all? {|cell| cell == row.first}
-       all_cells_match && not_nil_symbol(row.first)
-    end
+    @all_rows ||= rows.find do |row|
+           all_cells_match = row.all? {|cell| cell == row.first}
+           all_cells_match && not_nil_symbol(row.first)
+        end
   end
 
   def not_nil_row(row)
@@ -55,7 +55,7 @@ class Board
   end
 
   def all_rows
-    rows + columns + diagonals
+    @all ||= rows + columns + diagonals
   end
 
   def not_nil_symbol(cell)

--- a/spec/ai_player_spec.rb
+++ b/spec/ai_player_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe AiPlayer do
 
   it "scores zero when a draw is made" do
     draw_board = Board.new([PlayerSymbols::X, PlayerSymbols::O, PlayerSymbols::X, PlayerSymbols::X, PlayerSymbols::O, PlayerSymbols::O, PlayerSymbols::O, PlayerSymbols::X, PlayerSymbols::X])
-    expect(ai_player.minimax(draw_board, true, draw_board.vacant_indices.size).first.first).to be (0 + draw_board.vacant_indices.size)
+    expect(ai_player.minimax(draw_board, true, draw_board.vacant_indices.size, -2, 2).first.first).to be (0 + draw_board.vacant_indices.size)
   end
 
   it "scores one if computer wins" do
     winning_board = Board.new([PlayerSymbols::X, PlayerSymbols::X, PlayerSymbols::X, nil, nil, PlayerSymbols::O, PlayerSymbols::O, nil, nil])
 
-    expect(ai_player.minimax(winning_board, true, winning_board.vacant_indices.size).first.first).to be(1 + winning_board.vacant_indices.size)
+    expect(ai_player.minimax(winning_board, true, winning_board.vacant_indices.size, -2, 2).first.first).to be(1 + winning_board.vacant_indices.size)
   end
 
   it "scores negative one if opponent wins" do
     winning_board = Board.new([PlayerSymbols::O, PlayerSymbols::O, PlayerSymbols::O, nil, nil, PlayerSymbols::X, PlayerSymbols::X, nil, nil])
 
-    expect(ai_player.minimax(winning_board, true, winning_board.vacant_indices.size).first.first).to be(-1 - winning_board.vacant_indices.size)
+    expect(ai_player.minimax(winning_board, true, winning_board.vacant_indices.size, -2, 2).first.first).to be(-1 - winning_board.vacant_indices.size)
   end
 
   it "takes a winning move on top row" do

--- a/spec/ai_player_spec.rb
+++ b/spec/ai_player_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe AiPlayer do
 
   it "scores zero when a draw is made" do
     draw_board = Board.new([PlayerSymbols::X, PlayerSymbols::O, PlayerSymbols::X, PlayerSymbols::X, PlayerSymbols::O, PlayerSymbols::O, PlayerSymbols::O, PlayerSymbols::X, PlayerSymbols::X])
-    expect(ai_player.minimax(draw_board, true, draw_board.vacant_indices.size).get_score).to be (0 + draw_board.vacant_indices.size)
+    expect(ai_player.minimax(draw_board, true, draw_board.vacant_indices.size).first.first).to be (0 + draw_board.vacant_indices.size)
   end
 
   it "scores one if computer wins" do
     winning_board = Board.new([PlayerSymbols::X, PlayerSymbols::X, PlayerSymbols::X, nil, nil, PlayerSymbols::O, PlayerSymbols::O, nil, nil])
 
-    expect(ai_player.minimax(winning_board, true, winning_board.vacant_indices.size).get_score).to be(1 + winning_board.vacant_indices.size)
+    expect(ai_player.minimax(winning_board, true, winning_board.vacant_indices.size).first.first).to be(1 + winning_board.vacant_indices.size)
   end
 
   it "scores negative one if opponent wins" do
     winning_board = Board.new([PlayerSymbols::O, PlayerSymbols::O, PlayerSymbols::O, nil, nil, PlayerSymbols::X, PlayerSymbols::X, nil, nil])
 
-    expect(ai_player.minimax(winning_board, true, winning_board.vacant_indices.size).get_score).to be(-1 - winning_board.vacant_indices.size)
+    expect(ai_player.minimax(winning_board, true, winning_board.vacant_indices.size).first.first).to be(-1 - winning_board.vacant_indices.size)
   end
 
   it "takes a winning move on top row" do


### PR DESCRIPTION
@jsuchy - I time boxed improving the minimax
- I removed the surplus classes and used a hash instead to store the best score=>move.
- regarding performance of the minimax algorithm, it now takes about 3-4 seconds for the ai player to take the first move on an empty board.  Findings and approach are detailed [here](http://gemcfadyen.github.io/georginam.com/2016/01/20/apprenticeship-day-70b.html)

Please let me know if I need to optimise further, in which case I'd maybe pair with someone to see if they can spot anything to optimise, or else plant the first move outside of the minimax algorithm. 

Thanks.
