### PR TITLE
Updates from ipm

### DIFF
--- a/lib/command_line_ui.rb
+++ b/lib/command_line_ui.rb
@@ -9,11 +9,47 @@ class CommandLineUI
     @reader = reader
   end
 
-  def get_move_from_player(board)
-    writer.show_board(board)
-    value = read_users_move
+  #template method
+  def validated_input
+    yield
+    value = reader.get_input
 
-    zero_indexed(get_validated_move(value, board))
+    #    while !some_validation_stuff
+    #      display_to_prompt_some_stuff
+    #      value = get_input
+    #    end
+    #    transform_valid_input
+  end
+
+  def get_move_from_player(board)
+    shows_board_and_prompts_for_move = lambda { 
+      writer.show_board(board)
+      writer.ask_for_next_move
+    }
+
+    value = validated_input(&shows_board_and_prompts_for_move)
+
+    while !valid?(value, board)
+      writer.show_board(board)
+      writer.error_message
+      value = read_users_move
+    end
+    zero_indexed(Integer(value))
+  end
+
+  def get_player_option
+    prompts_for_player_option = lambda {
+      writer.show_player_options
+    }
+
+    value = validated_input(&prompts_for_player_option)
+
+    #value = read_player_option
+    while !valid_player_option?(value)
+      writer.error_message
+      value = read_player_option
+    end
+    PlayerOptions::get_player_type_for_id(Integer(value))
   end
 
   def replay?
@@ -32,11 +68,6 @@ class CommandLineUI
       return writer.show_draw_message
     end
   end
-
-  def get_player_option
-    get_validated_player_option(read_player_option)
-  end
-
   private
 
   attr_reader :writer, :reader

--- a/lib/command_line_ui.rb
+++ b/lib/command_line_ui.rb
@@ -1,6 +1,8 @@
 require 'prompt_writer'
 require 'prompt_reader'
 require 'player_options'
+require 'valid_move_finder'
+require 'valid_player_option_finder'
 
 class CommandLineUI
 
@@ -9,47 +11,12 @@ class CommandLineUI
     @reader = reader
   end
 
-  #template method
-  def validated_input
-    yield
-    value = reader.get_input
-
-    #    while !some_validation_stuff
-    #      display_to_prompt_some_stuff
-    #      value = get_input
-    #    end
-    #    transform_valid_input
-  end
-
   def get_move_from_player(board)
-    shows_board_and_prompts_for_move = lambda { 
-      writer.show_board(board)
-      writer.ask_for_next_move
-    }
-
-    value = validated_input(&shows_board_and_prompts_for_move)
-
-    while !valid?(value, board)
-      writer.show_board(board)
-      writer.error_message
-      value = read_users_move
-    end
-    zero_indexed(Integer(value))
+    ValidMoveFinder.new(board, reader, writer).validated_input
   end
 
   def get_player_option
-    prompts_for_player_option = lambda {
-      writer.show_player_options
-    }
-
-    value = validated_input(&prompts_for_player_option)
-
-    #value = read_player_option
-    while !valid_player_option?(value)
-      writer.error_message
-      value = read_player_option
-    end
-    PlayerOptions::get_player_type_for_id(Integer(value))
+    ValidPlayerOptionFinder.new(reader, writer).validated_input
   end
 
   def replay?
@@ -72,55 +39,4 @@ class CommandLineUI
 
   attr_reader :writer, :reader
 
-  def read_users_move
-    writer.ask_for_next_move
-    reader.get_input
-  end
-
-  def read_player_option
-    writer.show_player_options
-    reader.get_input
-  end
-
-  def get_validated_player_option(value)
-    while !valid_player_option?(value)
-      writer.error_message
-      value = read_player_option
-    end
-    PlayerOptions::get_player_type_for_id(Integer(value))
-  end
-
-  def valid_player_option?(value)
-    numeric?(value) ?  PlayerOptions::valid_ids.include?(Integer(value)) : false
-  end
-
-  def get_validated_move(value, board)
-    while !valid?(value, board)
-      writer.show_board(board)
-      writer.error_message
-      value = read_users_move
-    end
-    Integer(value)
-  end
-
-  def valid?(value, board)
-    numeric?(value) ? one_indexed(board.vacant_indices).include?(Integer(value)) : false
-  end
-
-  def numeric?(input)
-    begin
-      Integer(input)
-      true
-    rescue ArgumentError
-      false
-    end
-  end
-
-  def one_indexed(vacant_indices)
-    vacant_indices.collect { |i| i + 1 }
-  end
-
-  def zero_indexed(value)
-    value - 1
-  end
 end

--- a/lib/command_line_ui.rb
+++ b/lib/command_line_ui.rb
@@ -56,11 +56,11 @@ class CommandLineUI
       writer.error_message
       value = read_player_option
     end
-    PlayerOptions::get_player_type_for_id(to_number(value))
+    PlayerOptions::get_player_type_for_id(Integer(value))
   end
 
   def valid_player_option?(value)
-    numeric?(value) ?  PlayerOptions::valid_ids.include?(to_number(value)) : false
+    numeric?(value) ?  PlayerOptions::valid_ids.include?(Integer(value)) : false
   end
 
   def get_validated_move(value, board)
@@ -69,22 +69,20 @@ class CommandLineUI
       writer.error_message
       value = read_users_move
     end
-    to_number(value)
+    Integer(value)
   end
 
   def valid?(value, board)
-    numeric?(value) ? one_indexed(board.vacant_indices).include?(to_number(value)) : false
+    numeric?(value) ? one_indexed(board.vacant_indices).include?(Integer(value)) : false
   end
 
   def numeric?(input)
-    to_number(input)
-    true
-  rescue ArgumentError
-    false
-  end
-
-  def to_number(value)
-    Integer(value)
+    begin
+      Integer(input)
+      true
+    rescue ArgumentError
+      false
+    end
   end
 
   def one_indexed(vacant_indices)

--- a/lib/input_validator.rb
+++ b/lib/input_validator.rb
@@ -1,0 +1,30 @@
+class InputValidator
+
+  def validated_input
+    prompt_user
+    value = read_input
+
+    while !valid?(value)
+      reprompt
+      value = read_input
+    end
+    convert(value)
+  end
+
+  def numeric?(input)
+    begin
+      Integer(input)
+      true
+    rescue ArgumentError
+      false
+    end
+  end
+
+  private
+
+  def read_input
+    reader.get_input
+  end
+end
+
+

--- a/lib/prompt_reader.rb
+++ b/lib/prompt_reader.rb
@@ -4,7 +4,7 @@ class PromptReader
     @std_in = std_in
   end
 
-  def get_input()
+  def get_input
     std_in.gets.chomp
   end
 

--- a/lib/valid_move_finder.rb
+++ b/lib/valid_move_finder.rb
@@ -1,0 +1,41 @@
+require 'input_validator'
+
+class ValidMoveFinder < InputValidator
+
+  def initialize(board, reader, writer)
+    @board = board
+    @reader = reader
+    @writer = writer
+  end
+
+  def prompt_user
+    writer.show_board(board)
+    writer.ask_for_next_move
+  end
+
+  def reprompt
+    writer.show_board(board)
+    writer.error_message
+    writer.ask_for_next_move
+  end
+
+  def convert(value)
+    zero_indexed(Integer(value))
+  end
+
+  def valid?(value)
+    numeric?(value) ? one_indexed(board.vacant_indices).include?(Integer(value)) : false
+  end
+
+  private
+
+  attr_reader :board, :reader, :writer
+
+  def one_indexed(vacant_indices)
+    vacant_indices.collect { |i| i + 1 }
+  end
+
+  def zero_indexed(value)
+    value - 1
+  end
+end

--- a/lib/valid_player_option_finder.rb
+++ b/lib/valid_player_option_finder.rb
@@ -1,0 +1,32 @@
+require 'input_validator'
+require 'player_options'
+
+class ValidPlayerOptionFinder < InputValidator
+  def initialize(reader, writer)
+    @reader = reader
+    @writer = writer
+  end
+
+  def prompt_user
+    writer.show_player_options
+  end
+
+  def reprompt
+    writer.error_message
+    prompt_user
+  end
+
+  def convert(value)
+    PlayerOptions::get_player_type_for_id(Integer(value))
+  end
+
+  def valid?(value)
+    numeric?(value) ? PlayerOptions::valid_ids.include?(Integer(value)) : false
+  end
+
+  private
+
+  attr_reader :reader, :writer
+end
+
+

--- a/spec/player_options_spec.rb
+++ b/spec/player_options_spec.rb
@@ -23,6 +23,6 @@ RSpec.describe PlayerOptions do
   end
 
   it "gets player options for display" do
- expect(PlayerOptions::display_player_options).to eq("(1) #{PlayerOptions::HUMAN_VS_HUMAN}, (2) #{PlayerOptions::HUMAN_VS_AI}, (3) #{PlayerOptions::AI_VS_HUMAN}" )
+ expect(PlayerOptions::display_player_options).to eq("(1) Human vs Human, (2) Human vs Ai, (3) Ai vs Human" )
   end
 end

--- a/spec/valid_move_finder_spec.rb
+++ b/spec/valid_move_finder_spec.rb
@@ -1,0 +1,48 @@
+require 'valid_move_finder'
+require 'prompt_reader'
+require 'prompt_writer'
+require 'board'
+require 'player_symbols'
+
+RSpec.describe ValidMoveFinder do
+  let (:reader_spy) { instance_double(PromptReader).as_null_object }
+  let (:writer_spy) { instance_double(PromptWriter).as_null_object }
+  let (:valid_move_finder) { ValidMoveFinder.new(Board.new, reader_spy, writer_spy)}
+
+  it "prompts user to enter move" do
+    allow(reader_spy).to receive(:get_input).and_return("1")
+
+    value = valid_move_finder.validated_input
+
+    expect(value).to eq 0
+    expect(writer_spy).to have_received(:show_board)
+    expect(writer_spy).to have_received(:ask_for_next_move)
+  end
+
+
+  it "reprompts when non numeric move entered" do
+    allow(reader_spy).to receive(:get_input).and_return("a", "1")
+
+    value = valid_move_finder.validated_input
+
+    expect(value).to eq 0
+    expect(writer_spy).to have_received(:show_board).twice
+    expect(writer_spy).to have_received(:ask_for_next_move).twice
+    expect(writer_spy).to have_received(:error_message)
+  end
+
+  it "reprompts when already occupied move entered" do
+    valid_move_finder =  ValidMoveFinder.new(Board.new([PlayerSymbols::X, nil, nil, nil, nil, nil, nil, nil, nil]), reader_spy, writer_spy)
+
+    allow(reader_spy).to receive(:get_input).and_return("1", "7")
+
+    value = valid_move_finder.validated_input
+
+    expect(value).to eq 6
+    expect(writer_spy).to have_received(:show_board).twice
+    expect(writer_spy).to have_received(:ask_for_next_move).twice
+    expect(writer_spy).to have_received(:error_message)
+  end
+
+
+end

--- a/spec/valid_player_option_finder_spec.rb
+++ b/spec/valid_player_option_finder_spec.rb
@@ -1,0 +1,34 @@
+require 'valid_player_option_finder'
+require 'prompt_reader'
+require 'prompt_writer'
+require 'player_symbols'
+
+RSpec.describe ValidPlayerOptionFinder do
+  let (:reader_spy) { instance_double(PromptReader).as_null_object }
+  let (:writer_spy) { instance_double(PromptWriter).as_null_object }
+  let (:valid_player_option_finder) { ValidPlayerOptionFinder.new(reader_spy, writer_spy) }
+
+  it "reads in player option" do
+    allow(reader_spy).to receive(:get_input).and_return("1")
+
+    expect(valid_player_option_finder.validated_input).to be PlayerOptions::HUMAN_VS_HUMAN
+    expect(writer_spy).to have_received(:show_player_options)
+  end
+
+  it "reprompts when invalid player option entered" do
+    allow(reader_spy).to receive(:get_input).and_return("A", "1")
+
+    valid_player_option_finder.validated_input
+
+    expect(writer_spy).to have_received(:error_message)
+  end
+
+ it "reprompts player option from user when number is not a valid player type" do
+    allow(reader_spy).to receive(:get_input).and_return("32", "1")
+
+    expect(valid_player_option_finder.validated_input).to be PlayerOptions::HUMAN_VS_HUMAN
+
+    expect(writer_spy).to have_received(:show_player_options).twice
+    expect(reader_spy).to have_received(:get_input).twice
+  end
+end


### PR DESCRIPTION
@jsuchy @ecomba This pull request addresses the points we discussed in this mornings IPM meeting:
- The test for PlayerOptions now compare an actual string rather than the constants defined in the PlayerOptions class itself.
- begin/end block has been around the rescue block which converts an integer, so that it is clearer where the boundary of the exception handling lies.

@jsuchy - R.E: Addressing the duplication in the validating logic - I've used the template method as briefly mentioned in the IPM this morning. I'm not sure if it is an overall improvement!  Pro's and con's listed below and blogged [here](http://gemcfadyen.github.io/georginam.com/2016/01/26/apprenticeship-day-74.html).

Pro's: 
- The duplication has gone, the loop code is reused.  
- The levels of abstraction in the InputValidator class are consistent,
- I can see more clearly now that the steps of each validation are the same, but it is the contents of each step that is different. 
- Could argue each 'ValidValueFinder' now has a single responsibility, freeing up the cl-ui from finding the valid move, and the valid player option.

Con's: 
- The 'ValidValueFinders' are new'd up in the cl-ui, rather than being injected in. This is because one of them needs the latest state of the board, thus it can not be created up front. This meant I didn't want to remove any tests from the cl-ui, despite the validators being unit tested separately, because I can not verify that the new'd objects are being created.
- The validators need the reader, writer, so really are just an extension of the cl-ui, hence naming them was difficult.
- 2 more classes.

What do you think?

Beforehand, I looked at using yield, and lambda's, however it seems you can only pass one lambda in to a method, which will match with a yield, whereas here I would have lots of yields and would need a different lambda for each one. The method would end up looking like:

```
 def validate_input
   yield # prompt user
  value = reader.get_input

 while(yield) # some validation condition
    yield  # some reprompt
    value = reader.get_input
 end
   yield(value) # some transformation on the valid input
end 
```

which, even if possible, I felt that this would be a little confusing, as a new client would not know what each yield represents.
