### PR TITLE
Player symbols returned as a string for the web application

### DIFF
--- a/lib/player_symbols.rb
+++ b/lib/player_symbols.rb
@@ -7,7 +7,7 @@ class PlayerSymbols
   end
 
   def self.all
-    [X, O]
+    [X.to_s, O.to_s]
   end
 
   def self.to_symbol(value)

--- a/spec/player_symbols_spec.rb
+++ b/spec/player_symbols_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PlayerSymbols do
   end
 
   it "all player symbols as strings" do
-    expect(PlayerSymbols::all).to eq [:X.to_s, :O.to_s]
+    expect(PlayerSymbols::all).to eq ["X", "O"]
   end
 
   it "converts X to player symbol" do

--- a/spec/player_symbols_spec.rb
+++ b/spec/player_symbols_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe PlayerSymbols do
     expect(PlayerSymbols::opponent(PlayerSymbols::O)).to be :X
   end
 
-  it "all player symbols" do
-    expect(PlayerSymbols::all).to eq [:X, :O]
+  it "all player symbols as strings" do
+    expect(PlayerSymbols::all).to eq [:X.to_s, :O.to_s]
   end
 
   it "converts X to player symbol" do


### PR DESCRIPTION
@jsuchy @ecomba - small change to move the method that translates the player symbols to strings, into the class itself. This is so that this transformation does not have to be done in the web application.
