### PR TITLE
Ruby TTT: Ipm updates

### DIFF
--- a/lib/command_line_ui.rb
+++ b/lib/command_line_ui.rb
@@ -56,11 +56,11 @@ class CommandLineUI
       writer.error_message
       value = read_player_option
     end
-    PlayerOptions::get_player_type_for_id(to_number(value))
+    PlayerOptions::get_player_type_for_id(Integer(value))
   end
 
   def valid_player_option?(value)
-    numeric?(value) ?  PlayerOptions::valid_ids.include?(to_number(value)) : false
+    numeric?(value) ?  PlayerOptions::valid_ids.include?(Integer(value)) : false
   end
 
   def get_validated_move(value, board)
@@ -69,22 +69,20 @@ class CommandLineUI
       writer.error_message
       value = read_users_move
     end
-    to_number(value)
+    Integer(value)
   end
 
   def valid?(value, board)
-    numeric?(value) ? one_indexed(board.vacant_indices).include?(to_number(value)) : false
+    numeric?(value) ? one_indexed(board.vacant_indices).include?(Integer(value)) : false
   end
 
   def numeric?(input)
-    to_number(input)
-    true
-  rescue ArgumentError
-    false
-  end
-
-  def to_number(value)
-    Integer(value)
+    begin
+      Integer(input)
+      true
+    rescue ArgumentError
+      false
+    end
   end
 
   def one_indexed(vacant_indices)

--- a/spec/player_options_spec.rb
+++ b/spec/player_options_spec.rb
@@ -23,6 +23,6 @@ RSpec.describe PlayerOptions do
   end
 
   it "gets player options for display" do
- expect(PlayerOptions::display_player_options).to eq("(1) #{PlayerOptions::HUMAN_VS_HUMAN}, (2) #{PlayerOptions::HUMAN_VS_AI}, (3) #{PlayerOptions::AI_VS_HUMAN}" )
+ expect(PlayerOptions::display_player_options).to eq("(1) Human vs Human, (2) Human vs Ai, (3) Ai vs Human" )
   end
 end


### PR DESCRIPTION
@jsuchy @ecomba 

Here is an updated version (using `Proc`) of a template method for validating the user input in two places in the command line game:
- Validation when the user selects what player option they would like (HvH, CvH, HvC)
- Validation when the user enters their move

I prefer this version over the [initial PR](https://github.com/gemcfadyen/Apprenticeship-RubyTicTacToe/pull/14) because there are less classes, less complexity, the levels of abstractions have remained consistent, and I feel it is easier to see how the validation loop works.

For info, the differences between procs and lambdas has been blogged about [here](http://gemcfadyen.github.io/georginam.com/2016/02/01/apprenticeship-day-77.html)

This PR also includes the 2 other minor updates from last weeks IPM:
- The test for PlayerOptions now compare an actual string rather than the constants defined in the PlayerOptions class itself.
- begin/end block has been around the rescue block which converts an integer, so that it is clearer where the boundary of the exception handling lies.
